### PR TITLE
feat: add dns a record for kubernetes clusters in terraform

### DIFF
--- a/terraform/01_core_cluster/main.tf
+++ b/terraform/01_core_cluster/main.tf
@@ -26,3 +26,12 @@ module "public_ip" {
   resource_location   = module.resource_group.resource_location
   resource_group_name = module.resource_group.resource_group_name
 }
+
+module "a_record" {
+  source = "../modules/a_record"
+
+  record_name = "*.${var.environment_name}"
+  resource_group_name = module.resource_group.resource_group_name
+  target_resource_id = module.public_ip.id
+  zone_name = "demo.catena-x.net"
+}

--- a/terraform/modules/a_record/main.tf
+++ b/terraform/modules/a_record/main.tf
@@ -1,0 +1,7 @@
+resource "azurerm_dns_a_record" "a-record" {
+  name                = var.record_name
+  resource_group_name = var.resource_group_name
+  ttl                 = var.ttl
+  zone_name           = var.zone_name
+  target_resource_id  = var.target_resource_id
+}

--- a/terraform/modules/a_record/variables.tf
+++ b/terraform/modules/a_record/variables.tf
@@ -1,0 +1,25 @@
+variable "record_name" {
+  description = "The name of the A record. I.e. argo"
+  type        = string
+}
+
+variable "zone_name" {
+  description = "The name of the DNS zone, where the A record belongs to. I.e. demo.catena-x.net"
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "The name of the resource group this A Record belongs to"
+  type        = string
+}
+
+variable "target_resource_id" {
+  description = "The id of the resource this A record should point to. I.e. a public IP resource id"
+  type        = string
+}
+
+variable "ttl" {
+  description = "The time to live (ttl) value in seconds"
+  type        = number
+  default     = 0
+}

--- a/terraform/modules/public_ip/outputs.tf
+++ b/terraform/modules/public_ip/outputs.tf
@@ -1,3 +1,7 @@
 output "address" {
   value = azurerm_public_ip.public_ip.ip_address
 }
+
+output "id" {
+  value = azurerm_public_ip.public_ip.id
+}


### PR DESCRIPTION
When terraforming a new kubernetes environment, a wildcard DNS A record will be created pointing to a reserved public IP.
The A record will always be created in the demo.catena-x.net DNS Zone.
The wildcard will include the environment name, like for example '*.core', which will result in *.core.demo.catena-x.net as Domain.

Steps that have to follow this PR: 
- Fix the already existing wildcard record to point to the reserved public IP
- assign the public IP to the ingress controller of the core environment