### PR TITLE
Enable Default ApplicationSets

### DIFF
--- a/environments/core/cluster-secrets/vault-cluster-secret.yaml
+++ b/environments/core/cluster-secrets/vault-cluster-secret.yaml
@@ -1,4 +1,4 @@
-# TODO 08.04.2022 CARSLEN: cluster secret for vault missing in vault
+# TODO 08.04.2022 CARSLEN: bearerToken needs to be evaluated via SP login from kubeconfig
 apiVersion: v1
 kind: Secret
 metadata:

--- a/environments/core/kustomization.yaml
+++ b/environments/core/kustomization.yaml
@@ -5,6 +5,10 @@ namespace: argocd
 
 resources:
   - applicationsets/argo-applicationset.yaml
+  - applicationsets/ingress-applicationset.yaml
+  - applicationsets/certmanager-applicationset.yaml
+  - applicationsets/tls-applicationset.yaml
+  - applicationsets/reflector-applicationset.yaml
   - cluster-secrets/hotel-budapest-secret.yaml
 # TODO 08.04.2022 CARSLEN: after vault cluster secret is available in vault, enable it here for deployment
 #  - cluster-secrets/vault-cluster-secret.yaml


### PR DESCRIPTION
Enabled default applicationSets for core cluster in a first step. No ApplicationSet has any remote cluster enabled yet.