### PR TITLE
Use same AVP secret name for each team

### DIFF
--- a/environments/hotel-budapest/avp-secrets/bpdm-team-vault-secret.yaml
+++ b/environments/hotel-budapest/avp-secrets/bpdm-team-vault-secret.yaml
@@ -5,7 +5,7 @@ kind: Secret
 metadata:
   annotations:
     avp.kubernetes.io/path: "devsecops/data/avp-config/bpdm"
-  name: bpdm-team-vault-secret
+  name: vault-secret
   namespace: product-bpdm
 type: Opaque
 stringData:

--- a/environments/hotel-budapest/avp-secrets/data-format-transformer-team-vault-secret.yaml
+++ b/environments/hotel-budapest/avp-secrets/data-format-transformer-team-vault-secret.yaml
@@ -5,7 +5,7 @@ kind: Secret
 metadata:
   annotations:
     avp.kubernetes.io/path: "devsecops/data/avp-config/data-format-transformer"
-  name: data-format-transformer-team-vault-secret
+  name: vault-secret
   namespace: product-data-format-transformer
 type: Opaque
 stringData:

--- a/environments/hotel-budapest/avp-secrets/data-integrity-demonstrator-team-vault-secret.yaml
+++ b/environments/hotel-budapest/avp-secrets/data-integrity-demonstrator-team-vault-secret.yaml
@@ -5,7 +5,7 @@ kind: Secret
 metadata:
   annotations:
     avp.kubernetes.io/path: "devsecops/data/avp-config/data-integrity-demonstrator"
-  name: data-integrity-demonstrator-team-vault-secret
+  name: vault-secret
   namespace: product-data-integrity-demonstrator
 type: Opaque
 stringData:

--- a/environments/hotel-budapest/avp-secrets/devsecops-team-vault-secret.yaml
+++ b/environments/hotel-budapest/avp-secrets/devsecops-team-vault-secret.yaml
@@ -5,7 +5,7 @@ kind: Secret
 metadata:
   annotations:
     avp.kubernetes.io/path: "devsecops/data/avp-config/devsecops"
-  name: devsecops-team-vault-secret
+  name: vault-secret
   namespace: argocd
 type: Opaque
 stringData:

--- a/environments/hotel-budapest/avp-secrets/edc-team-vault-secret.yaml
+++ b/environments/hotel-budapest/avp-secrets/edc-team-vault-secret.yaml
@@ -5,7 +5,7 @@ kind: Secret
 metadata:
   annotations:
     avp.kubernetes.io/path: "devsecops/data/avp-config/edc"
-  name: edc-team-vault-secret
+  name: vault-secret
   namespace: product-edc
 type: Opaque
 stringData:

--- a/environments/hotel-budapest/avp-secrets/essential-services-team-vault-secret.yaml
+++ b/environments/hotel-budapest/avp-secrets/essential-services-team-vault-secret.yaml
@@ -5,7 +5,7 @@ kind: Secret
 metadata:
   annotations:
     avp.kubernetes.io/path: "devsecops/data/avp-config/essential-services"
-  name: essential-services-team-vault-secret
+  name: vault-secret
   namespace: product-essential-services
 type: Opaque
 stringData:

--- a/environments/hotel-budapest/avp-secrets/managed-identity-wallets-team-vault-secret.yaml
+++ b/environments/hotel-budapest/avp-secrets/managed-identity-wallets-team-vault-secret.yaml
@@ -5,7 +5,7 @@ kind: Secret
 metadata:
   annotations:
     avp.kubernetes.io/path: "devsecops/data/avp-config/managed-identity-wallets"
-  name: managed-identity-wallets-team-vault-secret
+  name: vault-secret
   namespace: product-managed-identity-wallets
 type: Opaque
 stringData:

--- a/environments/hotel-budapest/avp-secrets/material-pass-team-vault-secret.yaml
+++ b/environments/hotel-budapest/avp-secrets/material-pass-team-vault-secret.yaml
@@ -5,7 +5,7 @@ kind: Secret
 metadata:
   annotations:
     avp.kubernetes.io/path: "devsecops/data/avp-config/material-pass"
-  name: material-pass-team-vault-secret
+  name: vault-secret
   namespace: product-material-pass
 type: Opaque
 stringData:

--- a/environments/hotel-budapest/avp-secrets/portal-team-vault-secret.yaml
+++ b/environments/hotel-budapest/avp-secrets/portal-team-vault-secret.yaml
@@ -5,7 +5,7 @@ kind: Secret
 metadata:
   annotations:
     avp.kubernetes.io/path: "devsecops/data/avp-config/portal"
-  name: portal-team-vault-secret
+  name: vault-secret
   namespace: product-portal
 type: Opaque
 stringData:

--- a/environments/hotel-budapest/avp-secrets/semantics-team-vault-secret.yaml
+++ b/environments/hotel-budapest/avp-secrets/semantics-team-vault-secret.yaml
@@ -5,7 +5,7 @@ kind: Secret
 metadata:
   annotations:
     avp.kubernetes.io/path: "devsecops/data/avp-config/semantics"
-  name: semantics-team-vault-secret
+  name: vault-secret
   namespace: product-semantics
 type: Opaque
 stringData:

--- a/environments/hotel-budapest/avp-secrets/template-team-vault-secret.yaml.example
+++ b/environments/hotel-budapest/avp-secrets/template-team-vault-secret.yaml.example
@@ -5,7 +5,7 @@ kind: Secret
 metadata:
   annotations:
     avp.kubernetes.io/path: "devsecops/data/avp-config/TEAM-NAME"
-  name: TEAM-NAME-team-vault-secret
+  name: vault-secret
   namespace: product-TEAM-NAME
 type: Opaque
 stringData:

--- a/environments/hotel-budapest/avp-secrets/traceability-dft-team-vault-secret.yaml
+++ b/environments/hotel-budapest/avp-secrets/traceability-dft-team-vault-secret.yaml
@@ -5,7 +5,7 @@ kind: Secret
 metadata:
   annotations:
     avp.kubernetes.io/path: "devsecops/data/avp-config/traceability-dft"
-  name: traceability-dft-team-vault-secret
+  name: vault-secret
   namespace: product-traceability-dft
 type: Opaque
 stringData:

--- a/environments/hotel-budapest/avp-secrets/traceablity-irs-team-vault-secret.yaml
+++ b/environments/hotel-budapest/avp-secrets/traceablity-irs-team-vault-secret.yaml
@@ -5,7 +5,7 @@ kind: Secret
 metadata:
   annotations:
     avp.kubernetes.io/path: "devsecops/data/avp-config/traceablity-irs"
-  name: traceablity-irs-team-vault-secret
+  name: vault-secret
   namespace: product-traceability-irs
 type: Opaque
 stringData:


### PR DESCRIPTION
This PR names all the team secrets for ArgoCD Vault Plugin the same. This will make it easier to identify the secret needed to configure the vault integration. 
Name conflicts wont happen, because every team is running in its own namespace, and so is the AVP secret