### PR TITLE
renamed default policy to minimal

### DIFF
--- a/apps/argocd/base/argocd-rbac-cm.yaml
+++ b/apps/argocd/base/argocd-rbac-cm.yaml
@@ -5,10 +5,10 @@ metadata:
   labels:
     app.kubernetes.io/part-of: argocd
 data:
-  policy.default: role:none
+  policy.default: role:minimal
   scopes: '[groups, email]'
   policy.csv: |
-    p, role:none, application, *, */*, deny
-    p, role:none, clusters, get, *, allow
-    p, role:none, repositories, get, *, allow
+    p, role:minimal, application, *, */*, deny
+    p, role:minimal, clusters, get, *, allow
+    p, role:minimal, repositories, get, *, allow
     g, catenax-ng:ArgoCDAdmins, role:admin

--- a/apps/argocd/base/argocd-rbac-cm.yaml
+++ b/apps/argocd/base/argocd-rbac-cm.yaml
@@ -8,7 +8,7 @@ data:
   policy.default: role:minimal
   scopes: '[groups, email]'
   policy.csv: |
-    p, role:minimal, application, *, */*, deny
+    p, role:minimal, applications, *, */*, deny
     p, role:minimal, clusters, get, *, allow
     p, role:minimal, repositories, get, *, allow
     g, catenax-ng:ArgoCDAdmins, role:admin


### PR DESCRIPTION
Product-team member were not able to:
- pick targetRepository path from sugestion list
- pick destination from sugestion list

Fix was to adjust the default rbac rules in `argocd-rbac-cm.yaml`:
- still deny access to all _applications_ 
- allow get cluster resources
- allow get repositories

The hard deny on all resources prevented to receive these sugestion lists (example for _Path_):

![image](https://user-images.githubusercontent.com/28647218/164042123-204b948d-ef1d-41e9-a329-628c373f1e75.png)


As the role name _none_ doesn't match any longer, renamed policy to _minimal_.