### PR TITLE
feat: A1ODT-508 Add initial argo projects to dev env

### DIFF
--- a/environments/dev/argo-projects/product-bpdm.yaml
+++ b/environments/dev/argo-projects/product-bpdm.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: product-bpdm
+---
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: project-bpdm
+  namespace: argocd
+spec:
+  description: Project for team BPDM
+  sourceRepos:
+    - '*'
+  destinations:
+    - namespace: product-bpdm
+      server: https://kubernetes.default.svc
+  # Allow all namespaced-scoped resources to be created, except for ResourceQuota, LimitRange, NetworkPolicy
+  namespaceResourceBlacklist:
+    - group: ''
+      kind: ResourceQuota
+    - group: ''
+      kind: LimitRange
+    - group: ''
+      kind: NetworkPolicy
+  roles:
+    - name: team-admin
+      description: All access to applications inside project-bpdm. Read only on project itself
+      policies:
+        - p, proj:project-bpdm:team-admin, applications, *, project-bpdm/*, allow
+      groups:
+        - catenax-ng:product-bpdm

--- a/environments/dev/argo-projects/product-catenax-at-home.yaml
+++ b/environments/dev/argo-projects/product-catenax-at-home.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: catenax-at-home
+  name: product-catenax-at-home
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject

--- a/environments/dev/argo-projects/product-catenax-at-home.yaml
+++ b/environments/dev/argo-projects/product-catenax-at-home.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: catenax-at-home
+---
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: project-catenax-at-home
+  namespace: argocd
+spec:
+  description: "Project for team Catena-X@Home"
+  sourceRepos:
+    - '*'
+  destinations:
+    - namespace: catenax-at-home
+      server: https://kubernetes.default.svc
+  namespaceResourceBlacklist:
+    - group: ''
+      kind: ResourceQuota
+    - group: ''
+      kind: LimitRange
+    - group: ''
+      kind: NetworkPolicy
+  roles:
+    # A role which provides access to all applications in the project
+    - name: team-admin
+      description: All access to applications inside project-edc. Read only on project itself
+      policies:
+        - p, proj:project-catenax-at-home, applications, *, project-catenax-at-home/*, allow
+      groups:
+        - catenax-ng:product-catenax-at-home

--- a/environments/dev/argo-projects/product-data-format-transformer.yaml
+++ b/environments/dev/argo-projects/product-data-format-transformer.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: product-data-format-transformer
+---
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: project-data-format-transformer
+  namespace: argocd
+spec:
+  description: Project for team DataFormatTransformer.
+  sourceRepos:
+    - '*'
+  destinations:
+    - namespace: product-data-format-transformer
+      server: https://kubernetes.default.svc
+  # Allow all namespaced-scoped resources to be created, except for ResourceQuota, LimitRange, NetworkPolicy
+  namespaceResourceBlacklist:
+    - group: ''
+      kind: ResourceQuota
+    - group: ''
+      kind: LimitRange
+    - group: ''
+      kind: NetworkPolicy
+  roles:
+    - name: team-admin
+      description: All access to applications inside project-data-format-transformer. Read only on project itself
+      policies:
+        - p, proj:project-data-format-transformer:team-admin, applications, *, project-data-format-transformer/*, allow
+      groups:
+        - catenax-ng:product-data-format-transformer

--- a/environments/dev/argo-projects/product-data-integritiy-demonstrator.yaml
+++ b/environments/dev/argo-projects/product-data-integritiy-demonstrator.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: product-data-integrity-demonstrator
+---
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: project-data-integrity-demonstrator
+  namespace: argocd
+spec:
+  description: Project for team DataIntegrityDemonstrator
+  sourceRepos:
+    - '*'
+  destinations:
+    - namespace: product-data-integrity-demonstrator
+      server: https://kubernetes.default.svc
+  # Allow all namespaced-scoped resources to be created, except for ResourceQuota, LimitRange, NetworkPolicy
+  namespaceResourceBlacklist:
+    - group: ''
+      kind: ResourceQuota
+    - group: ''
+      kind: LimitRange
+    - group: ''
+      kind: NetworkPolicy
+  roles:
+    # A role which provides access to all applications in the project
+    - name: team-admin
+      description: All access to applications inside project-data-integrity-demonstrator. Read only on project itself
+      policies:
+        - p, proj:project-data-integrity-demonstrator:team-admin, applications, *, project-data-integrity-demonstrator/*, allow
+      groups:
+        - catenax-ng:product-data-integrity-demonstrator

--- a/environments/dev/argo-projects/product-edc.yaml
+++ b/environments/dev/argo-projects/product-edc.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: product-edc
+---
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: project-edc
+  namespace: argocd
+spec:
+  description: Project for team EDC
+  sourceRepos:
+    - '*'
+  destinations:
+    - namespace: product-edc
+      server: https://kubernetes.default.svc
+  namespaceResourceBlacklist:
+    - group: ''
+      kind: ResourceQuota
+    - group: ''
+      kind: LimitRange
+    - group: ''
+      kind: NetworkPolicy
+  roles:
+    # A role which provides access to all applications in the project
+    - name: team-admin
+      description: All access to applications inside project-edc. Read only on project itself
+      policies:
+        - p, proj:project-edc:team-admin, applications, *, project-edc/*, allow
+      groups:
+        - catenax-ng:product-edc

--- a/environments/dev/argo-projects/product-essential-services.yaml
+++ b/environments/dev/argo-projects/product-essential-services.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: product-essential-services
+---
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: project-essential-services
+  namespace: argocd
+spec:
+  description: Project for team essential services
+  sourceRepos:
+    - '*'
+  destinations:
+    - namespace: product-essential-services
+      server: https://kubernetes.default.svc
+  # Deny all cluster-scoped resources from being created, except for Namespace
+  clusterResourceWhitelist:
+    - group: ''
+      kind: Namespace
+  # Allow all namespaced-scoped resources to be created, except for ResourceQuota, LimitRange, NetworkPolicy
+  namespaceResourceBlacklist:
+    - group: ''
+      kind: ResourceQuota
+    - group: ''
+      kind: LimitRange
+    - group: ''
+      kind: NetworkPolicy
+  roles:
+    # A role which provides access to all applications in the project
+    - name: team-admin
+      description: All access to applications inside project-essential-services. Read only on project itself
+      policies:
+        - p, proj:project-essential-services:team-admin, applications, *, project-essential-services/*, allow
+      groups:
+        - catenax-ng:product-essential-services

--- a/environments/dev/argo-projects/product-managed-identity-wallets.yaml
+++ b/environments/dev/argo-projects/product-managed-identity-wallets.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: product-managed-identity-wallets
+---
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: project-managed-identity-wallets
+  namespace: argocd
+spec:
+  description: Project for team managed identity wallets.
+  sourceRepos:
+    - '*'
+  destinations:
+    - namespace: product-managed-identity-wallets
+      server: https://kubernetes.default.svc
+  # Allow all namespaced-scoped resources to be created, except for ResourceQuota, LimitRange, NetworkPolicy
+  namespaceResourceBlacklist:
+    - group: ''
+      kind: ResourceQuota
+    - group: ''
+      kind: LimitRange
+    - group: ''
+      kind: NetworkPolicy
+  roles:
+    # A role which provides access to all applications in the project
+    - name: team-admin
+      description: All access to applications inside project-managed-identity-wallets. Read only on project itself
+      policies:
+        - p, proj:project-managed-identity-wallets:team-admin, applications, *, project-managed-identity-wallets/*, allow
+      groups:
+        - catenax-ng:product-managed-identity-wallets

--- a/environments/dev/argo-projects/product-material-pass.yaml
+++ b/environments/dev/argo-projects/product-material-pass.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: product-material-pass
+---
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: project-material-pass
+  namespace: argocd
+spec:
+  description: Project for team Material Pass.
+  sourceRepos:
+    - '*'
+  destinations:
+    - namespace: product-material-pass
+      server: https://kubernetes.default.svc
+  # Allow all namespaced-scoped resources to be created, except for ResourceQuota, LimitRange, NetworkPolicy
+  namespaceResourceBlacklist:
+    - group: ''
+      kind: ResourceQuota
+    - group: ''
+      kind: LimitRange
+    - group: ''
+      kind: NetworkPolicy
+  roles:
+    - name: team-admin
+      description: All access to applications inside project-material-pass. Read only on project itself
+      policies:
+        - p, proj:project-material-pass:team-admin, applications, *, project-material-pass/*, allow
+      groups:
+        - catenax-ng:product-material-pass

--- a/environments/dev/argo-projects/product-portal.yaml
+++ b/environments/dev/argo-projects/product-portal.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: product-iam
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: product-portal
+---
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: project-portal
+  namespace: argocd
+spec:
+  description: Project for team Portal
+  sourceRepos:
+    - '*'
+  destinations:
+    - namespace: product-portal
+      server: https://kubernetes.default.svc
+    - namespace: product-iam
+      server: https://kubernetes.default.svc
+  # Allow all namespaced-scoped resources to be created, except for ResourceQuota, LimitRange, NetworkPolicy
+  namespaceResourceBlacklist:
+    - group: ''
+      kind: ResourceQuota
+    - group: ''
+      kind: LimitRange
+    - group: ''
+      kind: NetworkPolicy
+  roles:
+    # A role which provides access to all applications in the project
+    - name: team-admin
+      description: All access to applications inside project-portal. Read only on project itself
+      policies:
+        - p, proj:project-portal:team-admin, applications, *, project-portal/*, allow
+      groups:
+        - catenax-ng:product-portal

--- a/environments/dev/argo-projects/product-semantics.yaml
+++ b/environments/dev/argo-projects/product-semantics.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: product-semantics
+---
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: project-semantics
+  namespace: argocd
+spec:
+  description: Project for team Semantics
+  sourceRepos:
+    - '*'
+  destinations:
+    - namespace: product-semantics
+      server: https://kubernetes.default.svc
+  # Allow all namespaced-scoped resources to be created, except for ResourceQuota, LimitRange, NetworkPolicy
+  namespaceResourceBlacklist:
+    - group: ''
+      kind: ResourceQuota
+    - group: ''
+      kind: LimitRange
+    - group: ''
+      kind: NetworkPolicy
+  roles:
+    # A role which provides access to all applications in the project
+    - name: team-admin
+      description: All access to applications inside project-portal. Read only on project itself
+      policies:
+        - p, proj:project-semantics:team-admin, applications, *, project-semantics/*, allow
+      groups:
+        - catenax-ng:product-semantics

--- a/environments/dev/argo-projects/product-test-data-generator.yaml
+++ b/environments/dev/argo-projects/product-test-data-generator.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: product-test-data-generator
+---
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: project-test-data-generator
+  namespace: argocd
+spec:
+  description: Project for Test data generator.
+  sourceRepos:
+    - '*'
+  destinations:
+    - namespace: product-test-data-generator
+      server: https://kubernetes.default.svc
+  # Allow all namespaced-scoped resources to be created, except for ResourceQuota, LimitRange, NetworkPolicy
+  namespaceResourceBlacklist:
+    - group: ''
+      kind: ResourceQuota
+    - group: ''
+      kind: LimitRange
+    - group: ''
+      kind: NetworkPolicy
+  roles:
+    - name: team-admin
+      description: All access to applications inside project-test-data-generator. Read only on project itself
+      policies:
+        - p, proj:project-test-data-generator:team-admin, applications, *, project-test-data-generator/*, allow
+      groups:
+        - catenax-ng:product-test-data-generator

--- a/environments/dev/argo-projects/product-traceability-dft.yaml
+++ b/environments/dev/argo-projects/product-traceability-dft.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: product-traceability-dft
+---
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: project-traceability-dft
+  namespace: argocd
+spec:
+  description: Project for team traceability dft.
+  sourceRepos:
+    - '*'
+  destinations:
+    - namespace: product-traceability-dft
+      server: https://kubernetes.default.svc
+  # Allow all namespaced-scoped resources to be created, except for ResourceQuota, LimitRange, NetworkPolicy
+  namespaceResourceBlacklist:
+    - group: ''
+      kind: ResourceQuota
+    - group: ''
+      kind: LimitRange
+    - group: ''
+      kind: NetworkPolicy
+  roles:
+    # A role which provides access to all applications in the project
+    - name: team-admin
+      description: All access to applications inside project-traceability-dft. Read only on project itself
+      policies:
+        - p, proj:project-traceability-dft:team-admin, applications, *, project-traceability-dft/*, allow
+      groups:
+        - catenax-ng:product-traceability-dft

--- a/environments/dev/argo-projects/product-traceability-irs.yaml
+++ b/environments/dev/argo-projects/product-traceability-irs.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: product-traceability-irs
+---
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: project-traceability-irs
+  namespace: argocd
+spec:
+  description: Project for team traceability irs
+  sourceRepos:
+    - '*'
+  destinations:
+    - namespace: product-traceability-irs
+      server: https://kubernetes.default.svc
+  # Allow all namespaced-scoped resources to be created, except for ResourceQuota, LimitRange, NetworkPolicy
+  namespaceResourceBlacklist:
+    - group: ''
+      kind: ResourceQuota
+    - group: ''
+      kind: LimitRange
+    - group: ''
+      kind: NetworkPolicy
+  roles:
+    # A role which provides access to all applications in the project
+    - name: team-admin
+      description: All access to applications project-traceability-irs. Read only on project itself
+      policies:
+        - p, proj:project-traceability-irs:team-admin, applications, *, project-traceability-irs/*, allow
+      groups:
+        - catenax-ng:product-traceability-irs

--- a/environments/dev/argo-repos/product-semantics-repo.yaml
+++ b/environments/dev/argo-repos/product-semantics-repo.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: product-semantics-repo
+  namespace: argocd
+  annotations:
+    avp.kubernetes.io/path: "semantics/data/deploy-key"
+  labels:
+    argocd.argoproj.io/secret-type: repository
+stringData:
+  type: git
+  url: git@github.com:catenax-ng/product-semantics
+  name: product-semantics-repo
+  project: project-semantics
+  sshPrivateKey: |
+    <semantics-deploy-key>

--- a/environments/dev/argo-repos/product-test-data-generator-repo.yaml
+++ b/environments/dev/argo-repos/product-test-data-generator-repo.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: product-test-data-generator-repo
+  namespace: argocd
+  annotations:
+    avp.kubernetes.io/path: "test-data-generator/data/deploy-key"
+  labels:
+    argocd.argoproj.io/secret-type: repository
+stringData:
+  type: git
+  url: git@github.com:catenax-ng/product-test-data-generator
+  name: product-test-data-generator-repo
+  project: project-test-data-generator
+  sshPrivateKey: |
+    <test-data-generator-deploy-key>

--- a/environments/dev/avp-secrets/bpdm-team-vault-secret.yaml
+++ b/environments/dev/avp-secrets/bpdm-team-vault-secret.yaml
@@ -1,0 +1,16 @@
+# To onboard a new product team,replace TEAM-NAME with name of team in line 6 + 7
+# Save as TEAM-NAME-team-vault-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/path: "devsecops/data/avp-config/bpdm"
+  name: vault-secret
+  namespace: product-bpdm
+type: Opaque
+stringData:
+  VAULT_ADDR: https://vault.vault.demo.catena-x.net/
+  AVP_TYPE: vault
+  AVP_AUTH_TYPE: approle
+  AVP_ROLE_ID: <role_id>
+  AVP_SECRET_ID: <secret_id>

--- a/environments/dev/avp-secrets/catenax-at-home-team-vault-secret.yaml
+++ b/environments/dev/avp-secrets/catenax-at-home-team-vault-secret.yaml
@@ -1,0 +1,16 @@
+# To onboard a new product team,replace TEAM-NAME with name of team in line 6 + 7
+# Save as TEAM-NAME-team-vault-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/path: "devsecops/data/avp-config/catenax-at-home"
+  name: vault-secret
+  namespace: product-catenax-at-home
+type: Opaque
+stringData:
+  VAULT_ADDR: https://vault.vault.demo.catena-x.net/
+  AVP_TYPE: vault
+  AVP_AUTH_TYPE: approle
+  AVP_ROLE_ID: <role_id>
+  AVP_SECRET_ID: <secret_id>

--- a/environments/dev/avp-secrets/data-format-transformer-team-vault-secret.yaml
+++ b/environments/dev/avp-secrets/data-format-transformer-team-vault-secret.yaml
@@ -1,0 +1,16 @@
+# To onboard a new product team,replace TEAM-NAME with name of team in line 6 + 7
+# Save as TEAM-NAME-team-vault-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/path: "devsecops/data/avp-config/data-format-transformer"
+  name: vault-secret
+  namespace: product-data-format-transformer
+type: Opaque
+stringData:
+  VAULT_ADDR: https://vault.vault.demo.catena-x.net/
+  AVP_TYPE: vault
+  AVP_AUTH_TYPE: approle
+  AVP_ROLE_ID: <role_id>
+  AVP_SECRET_ID: <secret_id>

--- a/environments/dev/avp-secrets/data-integrity-demonstrator-team-vault-secret.yaml
+++ b/environments/dev/avp-secrets/data-integrity-demonstrator-team-vault-secret.yaml
@@ -1,0 +1,16 @@
+# To onboard a new product team,replace TEAM-NAME with name of team in line 7-9
+# Save as TEAM-NAME-team-vault-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/path: "devsecops/data/avp-config/data-integrity-demonstrator"
+  name: vault-secret
+  namespace: product-data-integrity-demonstrator
+type: Opaque
+stringData:
+  VAULT_ADDR: https://vault.vault.demo.catena-x.net/
+  AVP_TYPE: vault
+  AVP_AUTH_TYPE: approle
+  AVP_ROLE_ID: <role_id>
+  AVP_SECRET_ID: <secret_id>

--- a/environments/dev/avp-secrets/edc-team-vault-secret.yaml
+++ b/environments/dev/avp-secrets/edc-team-vault-secret.yaml
@@ -1,0 +1,16 @@
+# To onboard a new product team,replace TEAM-NAME with name of team in line 7-9
+# Save as TEAM-NAME-team-vault-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/path: "devsecops/data/avp-config/edc"
+  name: vault-secret
+  namespace: product-edc
+type: Opaque
+stringData:
+  VAULT_ADDR: https://vault.vault.demo.catena-x.net/
+  AVP_TYPE: vault
+  AVP_AUTH_TYPE: approle
+  AVP_ROLE_ID: <role_id>
+  AVP_SECRET_ID: <secret_id>

--- a/environments/dev/avp-secrets/essential-services-team-vault-secret.yaml
+++ b/environments/dev/avp-secrets/essential-services-team-vault-secret.yaml
@@ -1,0 +1,16 @@
+# To onboard a new product team,replace TEAM-NAME with name of team in line 7-9
+# Save as TEAM-NAME-team-vault-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/path: "devsecops/data/avp-config/essential-services"
+  name: vault-secret
+  namespace: product-essential-services
+type: Opaque
+stringData:
+  VAULT_ADDR: https://vault.vault.demo.catena-x.net/
+  AVP_TYPE: vault
+  AVP_AUTH_TYPE: approle
+  AVP_ROLE_ID: <role_id>
+  AVP_SECRET_ID: <secret_id>

--- a/environments/dev/avp-secrets/managed-identity-wallets-team-vault-secret.yaml
+++ b/environments/dev/avp-secrets/managed-identity-wallets-team-vault-secret.yaml
@@ -1,0 +1,16 @@
+# To onboard a new product team,replace TEAM-NAME with name of team in line 7-9
+# Save as TEAM-NAME-team-vault-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/path: "devsecops/data/avp-config/managed-identity-wallets"
+  name: vault-secret
+  namespace: product-managed-identity-wallets
+type: Opaque
+stringData:
+  VAULT_ADDR: https://vault.vault.demo.catena-x.net/
+  AVP_TYPE: vault
+  AVP_AUTH_TYPE: approle
+  AVP_ROLE_ID: <role_id>
+  AVP_SECRET_ID: <secret_id>

--- a/environments/dev/avp-secrets/material-pass-team-vault-secret.yaml
+++ b/environments/dev/avp-secrets/material-pass-team-vault-secret.yaml
@@ -1,0 +1,16 @@
+# To onboard a new product team,replace TEAM-NAME with name of team in line 7-9
+# Save as TEAM-NAME-team-vault-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/path: "devsecops/data/avp-config/material-pass"
+  name: vault-secret
+  namespace: product-material-pass
+type: Opaque
+stringData:
+  VAULT_ADDR: https://vault.vault.demo.catena-x.net/
+  AVP_TYPE: vault
+  AVP_AUTH_TYPE: approle
+  AVP_ROLE_ID: <role_id>
+  AVP_SECRET_ID: <secret_id>

--- a/environments/dev/avp-secrets/portal-team-vault-secret.yaml
+++ b/environments/dev/avp-secrets/portal-team-vault-secret.yaml
@@ -1,0 +1,16 @@
+# To onboard a new product team,replace TEAM-NAME with name of team in line 7-9
+# Save as TEAM-NAME-team-vault-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/path: "devsecops/data/avp-config/portal"
+  name: vault-secret
+  namespace: product-portal
+type: Opaque
+stringData:
+  VAULT_ADDR: https://vault.vault.demo.catena-x.net/
+  AVP_TYPE: vault
+  AVP_AUTH_TYPE: approle
+  AVP_ROLE_ID: <role_id>
+  AVP_SECRET_ID: <secret_id>

--- a/environments/dev/avp-secrets/semantics-team-vault-secret.yaml
+++ b/environments/dev/avp-secrets/semantics-team-vault-secret.yaml
@@ -1,0 +1,16 @@
+# To onboard a new product team,replace TEAM-NAME with name of team in line 7-9
+# Save as TEAM-NAME-team-vault-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/path: "devsecops/data/avp-config/semantics"
+  name: vault-secret
+  namespace: product-semantics
+type: Opaque
+stringData:
+  VAULT_ADDR: https://vault.vault.demo.catena-x.net/
+  AVP_TYPE: vault
+  AVP_AUTH_TYPE: approle
+  AVP_ROLE_ID: <role_id>
+  AVP_SECRET_ID: <secret_id>

--- a/environments/dev/avp-secrets/template-team-vault-secret.yaml.example
+++ b/environments/dev/avp-secrets/template-team-vault-secret.yaml.example
@@ -1,0 +1,16 @@
+# To onboard a new product team,replace TEAM-NAME with name of team in line 7-9
+# Save as TEAM-NAME-team-vault-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/path: "devsecops/data/avp-config/TEAM-NAME"
+  name: vault-secret
+  namespace: product-TEAM-NAME
+type: Opaque
+stringData:
+  VAULT_ADDR: https://vault.vault.demo.catena-x.net/
+  AVP_TYPE: vault
+  AVP_AUTH_TYPE: approle
+  AVP_ROLE_ID: <role_id>
+  AVP_SECRET_ID: <secret_id>

--- a/environments/dev/avp-secrets/test-data-generator-team-vault-secret.yaml
+++ b/environments/dev/avp-secrets/test-data-generator-team-vault-secret.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/path: "devsecops/data/avp-config/test-data-generator"
+  name: vault-secret
+  namespace: product-test-data-generator
+type: Opaque
+stringData:
+  VAULT_ADDR: https://vault.vault.demo.catena-x.net/
+  AVP_TYPE: vault
+  AVP_AUTH_TYPE: approle
+  AVP_ROLE_ID: <role_id>
+  AVP_SECRET_ID: <secret_id>

--- a/environments/dev/avp-secrets/traceability-dft-team-vault-secret.yaml
+++ b/environments/dev/avp-secrets/traceability-dft-team-vault-secret.yaml
@@ -1,0 +1,16 @@
+# To onboard a new product team,replace TEAM-NAME with name of team in line 7-9
+# Save as TEAM-NAME-team-vault-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/path: "devsecops/data/avp-config/traceability-dft"
+  name: vault-secret
+  namespace: product-traceability-dft
+type: Opaque
+stringData:
+  VAULT_ADDR: https://vault.vault.demo.catena-x.net/
+  AVP_TYPE: vault
+  AVP_AUTH_TYPE: approle
+  AVP_ROLE_ID: <role_id>
+  AVP_SECRET_ID: <secret_id>

--- a/environments/dev/avp-secrets/traceablity-irs-team-vault-secret.yaml
+++ b/environments/dev/avp-secrets/traceablity-irs-team-vault-secret.yaml
@@ -1,0 +1,16 @@
+# To onboard a new product team,replace TEAM-NAME with name of team in line 7-9
+# Save as TEAM-NAME-team-vault-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/path: "devsecops/data/avp-config/traceablity-irs"
+  name: vault-secret
+  namespace: product-traceability-irs
+type: Opaque
+stringData:
+  VAULT_ADDR: https://vault.vault.demo.catena-x.net/
+  AVP_TYPE: vault
+  AVP_AUTH_TYPE: approle
+  AVP_ROLE_ID: <role_id>
+  AVP_SECRET_ID: <secret_id>

--- a/environments/dev/kustomization.yaml
+++ b/environments/dev/kustomization.yaml
@@ -1,8 +1,19 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-#namespace: argocd
-
 resources:
+  - argo-projects/product-bpdm.yaml
+  - argo-projects/product-catenax-at-home.yaml
+  - argo-projects/product-data-format-transformer.yaml
+  - argo-projects/product-data-integritiy-demonstrator.yaml
+  - argo-projects/product-edc.yaml
+  - argo-projects/product-essential-services.yaml
+  - argo-projects/product-managed-identity-wallets.yaml
+  - argo-projects/product-portal.yaml
+  - argo-projects/product-semantics.yaml
+  - argo-projects/product-test-data-generator.yaml
+  - argo-projects/product-traceability-dft.yaml
+  - argo-projects/product-traceability-irs.yaml
+
   - avp-secrets/devsecops-team-vault-secret.yaml
   - argo-projects/product-example.yaml

--- a/environments/dev/kustomization.yaml
+++ b/environments/dev/kustomization.yaml
@@ -28,9 +28,11 @@ resources:
 
   - argo-projects/product-semantics.yaml
   - avp-secrets/semantics-team-vault-secret.yaml
+  - argo-repos/product-semantics-repo.yaml
 
   - argo-projects/product-test-data-generator.yaml
   - avp-secrets/test-data-generator-team-vault-secret.yaml
+  - argo-repos/product-test-data-generator-repo.yaml
 
   - argo-projects/product-traceability-dft.yaml
   - avp-secrets/traceability-dft-team-vault-secret.yaml

--- a/environments/dev/kustomization.yaml
+++ b/environments/dev/kustomization.yaml
@@ -3,17 +3,40 @@ kind: Kustomization
 
 resources:
   - argo-projects/product-bpdm.yaml
-  - argo-projects/product-catenax-at-home.yaml
-  - argo-projects/product-data-format-transformer.yaml
-  - argo-projects/product-data-integritiy-demonstrator.yaml
-  - argo-projects/product-edc.yaml
-  - argo-projects/product-essential-services.yaml
-  - argo-projects/product-managed-identity-wallets.yaml
-  - argo-projects/product-portal.yaml
-  - argo-projects/product-semantics.yaml
-  - argo-projects/product-test-data-generator.yaml
-  - argo-projects/product-traceability-dft.yaml
-  - argo-projects/product-traceability-irs.yaml
+  - avp-secrets/bpdm-team-vault-secret.yaml
 
-  - avp-secrets/devsecops-team-vault-secret.yaml
+  - argo-projects/product-catenax-at-home.yaml
+  - avp-secrets/catenax-at-home-team-vault-secret.yaml
+
+  - argo-projects/product-data-format-transformer.yaml
+  - avp-secrets/data-format-transformer-team-vault-secret.yaml
+
+  - argo-projects/product-data-integritiy-demonstrator.yaml
+  - avp-secrets/data-integrity-demonstrator-team-vault-secret.yaml
+
+  - argo-projects/product-edc.yaml
+  - avp-secrets/edc-team-vault-secret.yaml
+
+  - argo-projects/product-essential-services.yaml
+  - avp-secrets/essential-services-team-vault-secret.yaml
+
+  - argo-projects/product-managed-identity-wallets.yaml
+  - avp-secrets/managed-identity-wallets-team-vault-secret.yaml
+
+  - argo-projects/product-portal.yaml
+  - avp-secrets/portal-team-vault-secret.yaml
+
+  - argo-projects/product-semantics.yaml
+  - avp-secrets/semantics-team-vault-secret.yaml
+
+  - argo-projects/product-test-data-generator.yaml
+  - avp-secrets/test-data-generator-team-vault-secret.yaml
+
+  - argo-projects/product-traceability-dft.yaml
+  - avp-secrets/traceability-dft-team-vault-secret.yaml
+
+  - argo-projects/product-traceability-irs.yaml
+  - avp-secrets/traceablity-irs-team-vault-secret.yaml
+
   - argo-projects/product-example.yaml
+  - avp-secrets/devsecops-team-vault-secret.yaml


### PR DESCRIPTION
- Duplicating existing ArgoCD Projects, AVP secrets and ArgoCD repository definitions from INT to DEV
- Split EDC and catenax-at-home
- Remove -dev namespaces from projects, where existing 