### PR TITLE
FQDN for "hotel budapest" changed to argo.int.demo.catena-x.net

### DIFF
--- a/apps/argocd/overlays/hotel-budapest/configmap/argo-cm.yaml
+++ b/apps/argocd/overlays/hotel-budapest/configmap/argo-cm.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: argocd-cm
   annotations:
-    avp.kubernetes.io/path: "devsecops/data/clusters/hotel-budapest/github-oauth"
+    avp.kubernetes.io/path: "devsecops/data/clusters/int/github-oauth"
 data:
   dex.config: |
     connectors:
@@ -15,4 +15,4 @@ data:
           clientSecret: '<oAuthClientSecret>'
           orgs:
           - name: catenax-ng
-  url: "https://argo.demo.catena-x.net"
+  url: "https://argo.int.demo.catena-x.net"

--- a/apps/argocd/overlays/hotel-budapest/ingress/ingress-argocd.yaml
+++ b/apps/argocd/overlays/hotel-budapest/ingress/ingress-argocd.yaml
@@ -14,7 +14,7 @@ metadata:
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
 spec:
   rules:
-    - host: argo.demo.catena-x.net
+    - host: argo.int.demo.catena-x.net
       http:
         paths:
           - path: /
@@ -26,5 +26,5 @@ spec:
                   number: 443
   tls:
     - hosts:
-        - argo.demo.catena-x.net
+        - argo.int.demo.catena-x.net
       secretName: tls-secret


### PR DESCRIPTION
`argocd-cm.yaml` and `ingress-argocd.yaml` has been adjusted to new FQDN argo.int.demo.catena-x.net. Later on we've to rename the overlays  & co specifics