### PR TITLE
update ArgoCD to fix critical security issue

### DIFF
--- a/apps/argocd/base/kustomization.yaml
+++ b/apps/argocd/base/kustomization.yaml
@@ -4,7 +4,7 @@ namespace: argocd
 
 resources:
   - namespace.yaml
-  - https://raw.githubusercontent.com/argoproj/argo-cd/v2.3.3/manifests/ha/install.yaml
+  - https://raw.githubusercontent.com/argoproj/argo-cd/v2.3.4/manifests/ha/install.yaml
   - rbac-secret-access.yaml # grant avp access to secret with AVP configuration
 
 patchesStrategicMerge:

--- a/environments/core/applicationsets/argo-applicationset.yaml
+++ b/environments/core/applicationsets/argo-applicationset.yaml
@@ -9,17 +9,17 @@ spec:
       - cluster: core
         cluster-name: in-cluster
         overlay: overlays/core
-        targetRevision: HEAD
+        targetRevision: ArgoCD_v2.3.4
         AVP_SECRET: vault-secret
       - cluster: hotel-budapest
         cluster-name: hotel-budapest
         overlay: overlays/hotel-budapest
-        targetRevision: HEAD
+        targetRevision: ArgoCD_v2.3.4
         AVP_SECRET: vault-secret
       - cluster: dev
         cluster-name: dev
         overlay: overlays/dev
-        targetRevision: HEAD
+        targetRevision: ArgoCD_v2.3.4
         AVP_SECRET: vault-secret
 
   template:


### PR DESCRIPTION
Lift ArgoCD to v2.3.4 to cover https://github.com/argoproj/argo-cd/security/advisories/GHSA-r642-gv9p-2wjj