### PR TITLE
feat: A1ODT-504 create GitHub action repository

### DIFF
--- a/terraform/02_team_onboarding/main.tf
+++ b/terraform/02_team_onboarding/main.tf
@@ -936,7 +936,7 @@ module "github" {
     "gh-org-checks" : {
       name : "gh-org-checks"
       team_name : "argocdadmins"
-      description : "GitHub action to check for sane defaults throughout the organization"
+      description : "GitHub workflow to compile and overview of repository defaults compliance throughout the GitHub org"
       visibility : "public"
       homepage_url : ""
       topics : []
@@ -944,11 +944,8 @@ module "github" {
         enabled : false
       }
       is_template : false
-      uses_template : true
-      template : {
-        owner : "actions"
-        repository : "javascript-action"
-      }
+      uses_template : false
+      template : null
       codeowners_available : true
       codeowners : {
         review_count : 1

--- a/terraform/02_team_onboarding/main.tf
+++ b/terraform/02_team_onboarding/main.tf
@@ -933,7 +933,7 @@ module "github" {
       codeowners_available : false
       codeowners : null
     }
-    "gh-org-checks-action" : {
+    "gh-org-checks" : {
       name : "gh-org-checks"
       team_name : "argocdadmins"
       description : "GitHub action to check for sane defaults throughout the organization"
@@ -948,6 +948,11 @@ module "github" {
       template : {
         owner : "actions"
         repository : "javascript-action"
+      }
+      codeowners_available : true
+      codeowners : {
+        review_count : 1
+        pattern : "main"
       }
     }
   }

--- a/terraform/02_team_onboarding/main.tf
+++ b/terraform/02_team_onboarding/main.tf
@@ -933,6 +933,23 @@ module "github" {
       codeowners_available : false
       codeowners : null
     }
+    "gh-org-checks-action" : {
+      name : "gh-org-checks"
+      team_name : "argocdadmins"
+      description : "GitHub action to check for sane defaults throughout the organization"
+      visibility : "public"
+      homepage_url : ""
+      topics : []
+      pages : {
+        enabled : false
+      }
+      is_template : false
+      uses_template : true
+      template : {
+        owner : "actions"
+        repository : "javascript-action"
+      }
+    }
   }
 
   github_repositories_teams = {
@@ -1145,6 +1162,11 @@ module "github" {
       team_name : "product-knowledge"
       repository : "product-knowledge"
       permission : "maintain"
+    }
+    "gh-org-checks-argocdadmins" : {
+      team_name : "argocdadmins"
+      repository : "gh-org-checks"
+      permission : "admin"
     }
   }
 }

--- a/terraform/modules/github/main.tf
+++ b/terraform/modules/github/main.tf
@@ -80,7 +80,7 @@ EOT
 }
 
 resource "github_branch_protection" "branch_protection" {
-  for_each = local.codeowners_repos
+  for_each = { for k, v in local.codeowners_repos : k => v if v.visibility == "public"}
 
   repository_id                   = each.value.name
   pattern                         = each.value.codeowners.pattern


### PR DESCRIPTION
PR includes terraform code to create a new repository based on the https://github.com/actions/javascript-action template.

There is also a minor improvement for the branch protection resource. 
Problem: We want to create CODEOWNERS files on all repositories. This also adds branch protection. Branch protection can only be enabled on public repos. This lead to errors, when applying plans that created branch protection for private repos.
Now, private repos are excluded from the branch protection resource.

