### PR TITLE
Vault annotation adjustment

### DIFF
--- a/environments/core/cluster-secrets/hotel-budapest-secret.yaml
+++ b/environments/core/cluster-secrets/hotel-budapest-secret.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   annotations:
-    avp.kubernetes.io/path: "devsecops/data/clusters/hotel-budapest/k8s"
+    avp.kubernetes.io/path: "devsecops/data/clusters/int/k8s"
   labels:
     argocd.argoproj.io/secret-type: cluster
   name: hotel-budapest-cluster-secret


### PR DESCRIPTION
Moved Vault annotation from _hotel-budapest_ to _int_ to streamline our naming.

Created the referenced secret in new path. Old path ([devsecops/show/clusters/hotel-budapest/k8s](https://vault.demo.catena-x.net/ui/vault/secrets/devsecops/show/clusters/hotel-budapest/k8s)) will be removed, after merge to main.