### PR TITLE
feat: A1ODT-761 create release chart repo

### DIFF
--- a/terraform/02_team_onboarding/main.tf
+++ b/terraform/02_team_onboarding/main.tf
@@ -282,6 +282,14 @@ module "github" {
       "name" : "product-knowledge"
       "description" : "Catena-X Knowledge Agents delivers a semantically-driven and state-of-the-art compute-to-data architecture for automotive use cases based on the best GAIA-X, W3C and Big Data practices."
     }
+    "release-management" : {
+      name : "release-management"
+      description : "Members will be granted permissions to manage releases on release relevant environments"
+    }
+    "test-management" : {
+      name : "test-management"
+      description : "Members will be granted permissions to manage deployments on integration environments for testing purposes"
+    }
   }
 
   github_repositories = {
@@ -1132,6 +1140,23 @@ module "github" {
       codeowners_available : false
       codeowners : null
     }
+    "catena-x-release" : {
+      name : "catena-x-release"
+      team_name : "argocdadmins"
+      description : "A collection of helm Charts that represent different configurations of Catena-X releases"
+      visibility : "public"
+      homepage_url : ""
+      topics : []
+      pages : {
+        enabled : true
+        branch : "main"
+      }
+      is_template : false
+      uses_template : false
+      template : null
+      codeowners_available : false
+      codeowners : null
+    }
   }
 
   github_repositories_teams = {
@@ -1388,6 +1413,21 @@ module "github" {
     "product-vas-fraud-cd-product-value-added-service" : {
       team_name : "product-value-added-service"
       repository : "product-vas-fraud-cd"
+      permission : "maintain"
+    }
+    "catena-x-release-argocd-admins" : {
+      team_name : "argocdadmins"
+      repository : "catena-x-release"
+      permission : "admin"
+    }
+    "catena-x-release-release-management" : {
+      team_name : "release-management"
+      repository : "catena-x-release"
+      permission : "maintain"
+    }
+    "catena-x-release-test-management" : {
+      team_name : "test-management"
+      repository : "catena-x-release"
       permission : "maintain"
     }
   }

--- a/terraform/02_team_onboarding/main.tf
+++ b/terraform/02_team_onboarding/main.tf
@@ -280,7 +280,7 @@ module "github" {
     },
     "product-knowledge" : {
       "name" : "product-knowledge"
-      "description" : ""
+      "description" : "Catena-X Knowledge Agents delivers a semantically-driven and state-of-the-art compute-to-data architecture for automotive use cases based on the best GAIA-X, W3C and Big Data practices."
     }
   }
 
@@ -293,7 +293,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : ""
       }
       is_template : false
       uses_template : false
@@ -310,7 +311,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : ""
       }
       is_template : false
       uses_template : false
@@ -327,7 +329,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : ""
       }
       is_template : false
       uses_template : false
@@ -343,7 +346,8 @@ module "github" {
       homepage_url : "https://portal.dev.demo.catena-x.net"
       topics : ["catena-x", "docker", "portal", "react", "typescript"]
       pages : {
-        enabled : true
+        enabled : false
+        branch : ""
       }
       is_template : false
       uses_template : false
@@ -359,7 +363,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -376,6 +381,7 @@ module "github" {
       topics : []
       pages : {
         enabled : true
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -391,7 +397,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -407,7 +414,8 @@ module "github" {
       homepage_url : "https://catenax-ng.github.io/docs/catenax-at-home-getting-started-guide"
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -423,7 +431,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -439,7 +448,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -455,7 +465,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -471,7 +482,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -487,7 +499,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -503,7 +516,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -519,7 +533,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -535,7 +550,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -551,7 +567,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -567,7 +584,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -583,7 +601,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -599,7 +618,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -615,7 +635,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -631,7 +652,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -650,7 +672,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -666,7 +689,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -682,7 +706,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -698,7 +723,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -714,7 +740,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -730,7 +757,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -746,7 +774,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -762,7 +791,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -778,7 +808,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -794,7 +825,8 @@ module "github" {
       homepage_url : ""
       topics : ["internal"]
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -810,7 +842,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -827,6 +860,7 @@ module "github" {
       topics : ["ci-cd", "helm", "internal", "kubernetes"]
       pages : {
         enabled : true
+        branch : "gh-pages"
       }
       is_template : false
       uses_template : false
@@ -842,7 +876,8 @@ module "github" {
       homepage_url : "https://catenax-ng.github.io"
       topics : ["internal"]
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -858,7 +893,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -874,7 +910,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : true
       uses_template : false
@@ -890,7 +927,8 @@ module "github" {
       homepage_url : "https://portal.demo.catena-x.net/registration/"
       topics : ["catena-x", "frontend", "portal", "registration"]
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : true
@@ -909,7 +947,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -925,7 +964,8 @@ module "github" {
       homepage_url : ""
       topics : ["sparql", "rdf", "ids", "edc", "catena-x"]
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -941,7 +981,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -957,7 +998,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -976,7 +1018,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -995,7 +1038,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -1011,7 +1055,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -1027,7 +1072,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -1043,7 +1089,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -1059,7 +1106,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -1075,7 +1123,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : true
+        enabled : false
+        branch : "main"
       }
       is_template : false
       uses_template : false

--- a/terraform/02_team_onboarding/main.tf
+++ b/terraform/02_team_onboarding/main.tf
@@ -972,8 +972,8 @@ module "github" {
       homepage_url : ""
       topics : ["sparql", "rdf", "ids", "edc", "catena-x"]
       pages : {
-        enabled : false
-        branch : "main"
+        enabled : true
+        branch : "gh-pages"
       }
       is_template : false
       uses_template : false
@@ -1149,7 +1149,24 @@ module "github" {
       topics : []
       pages : {
         enabled : true
-        branch : "main"
+        branch : "gh-pages"
+      }
+      is_template : false
+      uses_template : false
+      template : null
+      codeowners_available : false
+      codeowners : null
+    }
+    "catena-x-release-deployment" : {
+      name : "catena-x-release-deployment"
+      team_name : "argocdadmins"
+      description : "Consortia deployment configuration for Catena-X releases"
+      visibility : "public"
+      homepage_url : ""
+      topics : []
+      pages : {
+        enabled : true
+        branch : "gh-pages"
       }
       is_template : false
       uses_template : false
@@ -1428,6 +1445,21 @@ module "github" {
     "catena-x-release-test-management" : {
       team_name : "test-management"
       repository : "catena-x-release"
+      permission : "maintain"
+    }
+    "catena-x-release-deployment-argocdadmins" : {
+      team_name : "argocdadmins"
+      repository : "catena-x-release-deployment"
+      permission : "admin"
+    }
+    "catena-x-release-deployment-release-management" : {
+      team_name : "release-management"
+      repository : "catena-x-release-deployment"
+      permission : "maintain"
+    }
+    "catena-x-release-deployment-test-management" : {
+      team_name : "test-management"
+      repository : "catena-x-release-deployment"
       permission : "maintain"
     }
   }

--- a/terraform/modules/github/main.tf
+++ b/terraform/modules/github/main.tf
@@ -34,7 +34,7 @@ resource "github_repository" "repositories" {
     for_each = each.value.pages.enabled ? [true] : []
     content {
       source {
-        branch = "gh-pages"
+        branch = each.value.pages.branch
       }
     }
   }

--- a/terraform/modules/github/variables.tf
+++ b/terraform/modules/github/variables.tf
@@ -11,6 +11,7 @@ variable "github_repositories" {
     topics       = set(string)
     pages        = object({
       enabled = bool
+      branch = string
     })
     is_template   = bool
     uses_template = bool


### PR DESCRIPTION
This PR adds a new repo 'catena-x-release' and two teams 'release-management' and 'test-management' to our terraform configuration.
Apparently the GitHub pages settings cannot be changed on existing repos via terraform. Most likely a permission issue, but even with a token with full permissions it could not be created (404 responses). 
On the new repositories, the GitHub pages feature is enabled as expected. 

Although changing the GitHub pages setting is resulting in 404, the state is updated, so there are no changes in GitHub, but the state is altered, so that on a second run, terraform does not apply any changes.

New repo is already created (tf apply...)