### PR TITLE
fix: change AVP init to helm dependency update to fix A1ODT-850

### DIFF
--- a/apps/argocd/base/avp-argocd-cm.yaml
+++ b/apps/argocd/base/avp-argocd-cm.yaml
@@ -11,14 +11,14 @@ data:
     - name: argocd-vault-plugin-helm
       init:
         command: [sh, -c]
-        args: ["helm dependency build -n $ARGOCD_APP_NAMESPACE"]
+        args: ["helm dependency update -n $ARGOCD_APP_NAMESPACE"]
       generate:
         command: ["sh", "-c"]
         args: ["helm template $ARGOCD_APP_NAME -n $ARGOCD_APP_NAMESPACE . | argocd-vault-plugin generate - -s vault-secret"]
     - name: argocd-vault-plugin-helm-args
       init:
         command: [sh, -c]
-        args: ["helm dependency build -n $ARGOCD_APP_NAMESPACE"]
+        args: ["helm dependency update -n $ARGOCD_APP_NAMESPACE"]
       generate:
         command: ["sh", "-c"]
         args: ["helm template $ARGOCD_APP_NAME -n $ARGOCD_APP_NAMESPACE ${helm_args} . | argocd-vault-plugin generate - -s vault-secret"]
@@ -29,7 +29,7 @@ data:
     - name: argocd-vault-plugin-kustomize-helm-args
       init:
           command: [sh, -c]
-          args: ["helm dependency build -n $ARGOCD_APP_NAMESPACE"]
+          args: ["helm dependency update -n $ARGOCD_APP_NAMESPACE"]
       generate:
         command: ["sh", "-c"]
         args: ["helm template $ARGOCD_APP_NAME -n $ARGOCD_APP_NAMESPACE ${helm_args} . > manifest.yaml && kustomize build | argocd-vault-plugin generate - -s vault-secret"]


### PR DESCRIPTION
HELM related ArgoCD Vault plugins where unable to build/update dependencies if App is created as HELM based instead of GIT. Error was 

```
Unable to create application: 
  application spec for backend-helm-test is invalid: 
    InvalidSpecError: Unable to generate manifests in : 
      rpc error: 
        code = Unknown 
        desc = `sh -c helm dependency build -n $ARGOCD_APP_NAMESPACE` failed exit status 1: 
          Error: no repository definition for https://charts.bitnami.com/bitnami, https://helm.runix.net. 
          Please add the missing repos via 'helm repo add'
```

Using `helm dependency update` instead of `helm dependency build` in init section of AVP definition solved the issue.