### PR TITLE
Build/bump argocd to v2.3.7

### DIFF
--- a/apps/argocd/base/kustomization.yaml
+++ b/apps/argocd/base/kustomization.yaml
@@ -4,7 +4,7 @@ namespace: argocd
 
 resources:
   - namespace.yaml
-  - https://raw.githubusercontent.com/argoproj/argo-cd/v2.3.4/manifests/ha/install.yaml
+  - https://raw.githubusercontent.com/argoproj/argo-cd/v2.3.7/manifests/ha/install.yaml
   - rbac-secret-access.yaml # grant avp access to secret with AVP configuration
 
 patchesStrategicMerge:

--- a/environments/core/applicationsets/argo-applicationset.yaml
+++ b/environments/core/applicationsets/argo-applicationset.yaml
@@ -21,7 +21,7 @@ spec:
       - cluster: devsecops-testing
         cluster-name: devsecops-testing
         overlay: overlays/devsecops-testing
-        targetRevision: onboarding-beta
+        targetRevision: ArgoCD-v2.3.7-testing
       - cluster: pre-prod
         cluster-name: pre-prod
         overlay: overlays/pre-prod


### PR DESCRIPTION
Bump ArgoCD version for DevSecOps-testing K8s cluster for testing purpose.