### PR TITLE
fix: fix reflector annotation for pull-secret, dos2unix

### DIFF
--- a/environments/beta/pull-secret/secret.yaml
+++ b/environments/beta/pull-secret/secret.yaml
@@ -1,11 +1,12 @@
 apiVersion: v1
-data:
-  .dockerconfigjson: <path:devsecops/data/acme/machine-user#machineuser-pull-secret-ro>
 kind: Secret
 metadata:
   annotations:
-    reflector.v1.k8s.emberstack.com/auto-reflects: "True"
-    reflector.v1.k8s.emberstack.com/reflects: default/machineuser-pull-secret-ro
+    reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+    reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+    reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "product-[a-zA-Z0-9\\-]*"
   name: machineuser-pull-secret-ro
   namespace: default
 type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: <path:devsecops/data/acme/machine-user#machineuser-pull-secret-ro>

--- a/environments/dev/pull-secret/secret.yaml
+++ b/environments/dev/pull-secret/secret.yaml
@@ -1,11 +1,12 @@
 apiVersion: v1
-data:
-  .dockerconfigjson: <path:devsecops/data/acme/machine-user#machineuser-pull-secret-ro>
 kind: Secret
 metadata:
   annotations:
-    reflector.v1.k8s.emberstack.com/auto-reflects: "True"
-    reflector.v1.k8s.emberstack.com/reflects: default/machineuser-pull-secret-ro
+    reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+    reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+    reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "product-[a-zA-Z0-9\\-]*"
   name: machineuser-pull-secret-ro
   namespace: default
 type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: <path:devsecops/data/acme/machine-user#machineuser-pull-secret-ro>

--- a/environments/devsecops-testing/pull-secret/secret.yaml
+++ b/environments/devsecops-testing/pull-secret/secret.yaml
@@ -1,11 +1,12 @@
 apiVersion: v1
-data:
-  .dockerconfigjson: <path:devsecops/data/acme/machine-user#machineuser-pull-secret-ro>
 kind: Secret
 metadata:
   annotations:
-    reflector.v1.k8s.emberstack.com/auto-reflects: "True"
-    reflector.v1.k8s.emberstack.com/reflects: default/machineuser-pull-secret-ro
+    reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+    reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+    reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "product-[a-zA-Z0-9\\-]*"
   name: machineuser-pull-secret-ro
   namespace: default
 type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: <path:devsecops/data/acme/machine-user#machineuser-pull-secret-ro>

--- a/environments/hotel-budapest/pull-secret/secret.yaml
+++ b/environments/hotel-budapest/pull-secret/secret.yaml
@@ -1,11 +1,12 @@
 apiVersion: v1
-data:
-  .dockerconfigjson: <path:devsecops/data/acme/machine-user#machineuser-pull-secret-ro>
 kind: Secret
 metadata:
   annotations:
-    reflector.v1.k8s.emberstack.com/auto-reflects: "True"
-    reflector.v1.k8s.emberstack.com/reflects: default/machineuser-pull-secret-ro
+    reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+    reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+    reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "product-[a-zA-Z0-9\\-]*"
   name: machineuser-pull-secret-ro
   namespace: default
 type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: <path:devsecops/data/acme/machine-user#machineuser-pull-secret-ro>

--- a/environments/pre-prod/pull-secret/secret.yaml
+++ b/environments/pre-prod/pull-secret/secret.yaml
@@ -1,11 +1,12 @@
 apiVersion: v1
-data:
-  .dockerconfigjson: <path:devsecops/data/acme/machine-user#machineuser-pull-secret-ro>
 kind: Secret
 metadata:
   annotations:
-    reflector.v1.k8s.emberstack.com/auto-reflects: "True"
-    reflector.v1.k8s.emberstack.com/reflects: default/machineuser-pull-secret-ro
+    reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+    reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+    reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "product-[a-zA-Z0-9\\-]*"
   name: machineuser-pull-secret-ro
   namespace: default
 type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: <path:devsecops/data/acme/machine-user#machineuser-pull-secret-ro>


### PR DESCRIPTION
Reflector specific annotation `reflector.v1.k8s.emberstack.com/reflects` in source secrets leads in deletion of source secret by reflector instead of reflect it to specific namespaces.

How to reproduce (done on cx-devsecops-testing-aks):
- Set `replicas` in Reflector deployment to `0` to temp. disable reflector.
- ArgoCD will immediately create the source secret in default namespace that contains the misplaced annotation.
- Set `replicas` in Reflector deployment back to `1` to enable reflector again.
- Source secret gets immediately deleted. 

This is the reason why the secret appears as flapping (OutOfSync <-> Sync).

Using the correct set of annotations fix the problem.