### PR TITLE
Fix Pre-Prod project role/policy

### DIFF
--- a/environments/pre-prod/argo-projects/product-bpdm.yaml
+++ b/environments/pre-prod/argo-projects/product-bpdm.yaml
@@ -28,6 +28,7 @@ spec:
       description: provide read-only access to project
       policies:
         - p, proj:project-bpdm:project-read-only, applications, get, project-bpdm/*, allow
+        - p, proj:project-bpdm:project-read-only, applications, get, default/*, allow
       groups:
         - catenax-ng:product-bpdm
         - catenax-ng:release-management

--- a/environments/pre-prod/argo-projects/product-daps.yaml
+++ b/environments/pre-prod/argo-projects/product-daps.yaml
@@ -28,6 +28,7 @@ spec:
       description: provide read-only access to project DAPS (managed by product-team essential-services)
       policies:
         - p, proj:project-daps:project-read-only, applications, get, project-daps/*, allow
+        - p, proj:project-daps:project-read-only, applications, get, default/*, allow
       groups:
         - catenax-ng:product-essential-services
         - catenax-ng:release-management

--- a/environments/pre-prod/argo-projects/product-managed-identity-wallets.yaml
+++ b/environments/pre-prod/argo-projects/product-managed-identity-wallets.yaml
@@ -28,6 +28,7 @@ spec:
       description: provide read-only access to project
       policies:
         - p, proj:project-managed-identity-wallets:project-read-only, applications, get, project-managed-identity-wallets/*, allow
+        - p, proj:project-managed-identity-wallets:project-read-only, applications, get, default/*, allow
       groups:
         - catenax-ng:product-managed-identity-wallets
         - catenax-ng:release-management

--- a/environments/pre-prod/argo-projects/product-portal.yaml
+++ b/environments/pre-prod/argo-projects/product-portal.yaml
@@ -28,6 +28,7 @@ spec:
       description: provide read-only access to project
       policies:
         - p, proj:project-portal:project-read-only, applications, get, project-portal/*, allow
+        - p, proj:project-portal:project-read-only, applications, get, default/*, allow
       groups:
         - catenax-ng:product-portal
         - catenax-ng:release-management

--- a/environments/pre-prod/argo-projects/product-sldt.yaml
+++ b/environments/pre-prod/argo-projects/product-sldt.yaml
@@ -28,6 +28,7 @@ spec:
       description: provide read-only access to project
       policies:
         - p, proj:project-sldt:project-read-only, applications, get, project-sldt/*, allow
+        - p, proj:project-sldt:project-read-only, applications, get, default/*, allow
       groups:
         - catenax-ng:product-semantics
         - catenax-ng:release-management


### PR DESCRIPTION
added policy to enable teams to view app deployed to _default_ project.