### PR TITLE
chore: add wave-a product-teams as collaborator to deploy repo; A1ODT-933

### DIFF
--- a/terraform/100_team_onboarding/main.tf
+++ b/terraform/100_team_onboarding/main.tf
@@ -1664,6 +1664,31 @@ module "github" {
       repository : "catena-x-release-deployment"
       permission : "maintain"
     },
+    "catena-x-release-deployment-product-portal" : {
+      team_name : "product-portal"
+      repository : "catena-x-release-deployment"
+      permission : "write"
+    },
+    "catena-x-release-deployment-product-semantics" : {
+      team_name : "product-semantics"
+      repository : "catena-x-release-deployment"
+      permission : "write"
+    },
+    "catena-x-release-deployment-product-essential-services" : {
+      team_name : "product-essential-services"
+      repository : "catena-x-release-deployment"
+      permission : "write"
+    },
+    "catena-x-release-deployment-product-bpdm" : {
+      team_name : "product-bpdm"
+      repository : "catena-x-release-deployment"
+      permission : "write"
+    },
+    "catena-x-release-deployment-product-managed-identity-wallets" : {
+      team_name : "product-managed-identity-wallets"
+      repository : "catena-x-release-deployment"
+      permission : "write"
+    },
     "product-data-integrity-demonstrator-product-trace-cs-webapp" : {
       team_name : "product-data-integrity-demonstrator"
       repository : "product-trace-cs-webapp"


### PR DESCRIPTION
These terraform changes will add all Release 2 wave A product teams as collaborator to our deployment repo.
This will enable 'write' access, so teams can open PRs from that repository without creating a fork.