### PR TITLE
Build/A1ODT-880: update avp

### DIFF
--- a/apps/argocd/base/plugins/argo-vault-plugin.yaml
+++ b/apps/argocd/base/plugins/argo-vault-plugin.yaml
@@ -17,14 +17,14 @@ spec:
         emptyDir: {}
       initContainers:
       - name: download-tools
-        image: alpine:3.8
+        image: alpine:3.16
         command: [sh, -c]
 
         # Don't forget to update this to whatever the stable release version is
         # Note the lack of the `v` prefix unlike the git tag
         env:
           - name: AVP_VERSION
-            value: "1.10.1"
+            value: "1.13.0"
         args:
           - >-
             wget -O argocd-vault-plugin

--- a/environments/core/applicationsets/argo-applicationset.yaml
+++ b/environments/core/applicationsets/argo-applicationset.yaml
@@ -21,7 +21,7 @@ spec:
       - cluster: devsecops-testing
         cluster-name: devsecops-testing
         overlay: overlays/devsecops-testing
-        targetRevision: ArgoCD-v2.3.7
+        targetRevision: ArgoCD-v2.3.7_AVP-v0.13.0
       - cluster: pre-prod
         cluster-name: pre-prod
         overlay: overlays/pre-prod


### PR DESCRIPTION
Bump AVP version to latest v0.13.0 and change ArgoCD Tag to be able to test it on DEVSECOPS-TESTING k8s cluster