### PR TITLE
feat: bump DEX chart to 0.12.1 (= dex v2.35.3) to fix security issue

### DIFF
--- a/apps/vault/Chart.yaml
+++ b/apps/vault/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
 
 - name: dex
   alias: dex
-  version: 0.8.2
+  version: 0.12.1
   repository: https://charts.dexidp.io
 
 


### PR DESCRIPTION
Bump version 