### PR TITLE
chore: add blockexplorer repo to Argo CD #A1ODT-964

### DIFF
--- a/environments/dev/argo-repos/product-esc-backbone-blockexplorer.yaml
+++ b/environments/dev/argo-repos/product-esc-backbone-blockexplorer.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: product-esc-backbone-blockexplorer
+  namespace: argocd
+  annotations:
+    avp.kubernetes.io/path: "esc-backbone/data/deploy-key"
+  labels:
+    argocd.argoproj.io/secret-type: repository
+stringData:
+  type: git
+  url: git@github.com:catenax-ng/product-esc-backbone-blockexplorer
+  name: product-esc-backbone-blockexplorer-repo
+  project: project-esc-backbone
+  sshPrivateKey: |
+    <product-esc-backbone-deploy-key>

--- a/environments/hotel-budapest/argo-repos/product-esc-backbone-blockexplorer.yaml
+++ b/environments/hotel-budapest/argo-repos/product-esc-backbone-blockexplorer.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: product-esc-backbone-blockexplorer
+  namespace: argocd
+  annotations:
+    avp.kubernetes.io/path: "esc-backbone/data/deploy-key"
+  labels:
+    argocd.argoproj.io/secret-type: repository
+stringData:
+  type: git
+  url: git@github.com:catenax-ng/product-esc-backbone-blockexplorer
+  name: product-esc-backbone-blockexplorer-repo
+  project: project-esc-backbone
+  sshPrivateKey: |
+    <product-esc-backbone-deploy-key>


### PR DESCRIPTION
Add product-esc-backbone-blockexplorer repo to our Argo CD instances (DEV and INT). 
