### PR TITLE
chore: fix vault r-strategy-assistant and TF state

### DIFF
--- a/terraform/100_team_onboarding/main.tf
+++ b/terraform/100_team_onboarding/main.tf
@@ -219,17 +219,17 @@ module "vault" {
       ui_policy_name : "item-relationship-service-frontend-rw"
       approle_name : "item-relationship-service-frontend"
       approle_policy_name : "item-relationship-service-frontend-ro"
-      github_team : "item-relationship-service-frontend"
+      github_team : "product-item-relationship-service-frontend"
       avp_secret_name : "item-relationship-service-frontend"
     },
-    "product-r-strategy-assistant" : {
-      name : "product-r-strategy-assistant",
-      secret_engine_name : "product-r-strategy-assistant"
-      ui_policy_name : "product-r-strategy-assistant-rw"
-      approle_name : "product-r-strategy-assistant"
-      approle_policy_name : "product-r-strategy-assistant-ro"
+    "r-strategy-assistant" : {
+      name : "r-strategy-assistant",
+      secret_engine_name : "r-strategy-assistant"
+      ui_policy_name : "r-strategy-assistant-rw"
+      approle_name : "r-strategy-assistant"
+      approle_policy_name : "r-strategy-assistant-ro"
       github_team : "product-r-strategy-assistant"
-      avp_secret_name : "product-r-strategy-assistant"
+      avp_secret_name : "r-strategy-assistant"
     }
   }
 }

--- a/terraform/100_team_onboarding/main.tf
+++ b/terraform/100_team_onboarding/main.tf
@@ -651,8 +651,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : false
-        branch : "main"
+        enabled : true
+        branch : "gh-pages"
       }
       is_template : false
       uses_template : false


### PR DESCRIPTION
Two commits:
- one to fix the vault stuff for new team r-strategy-assistant
- one to fix TF state out of sync regarding dft-frontend gh-pages

`terraform plan`output:
```shell
Terraform will perform the following actions:

  # module.vault.vault_approle_auth_backend_role.product-team-approles["product-r-strategy-assistant"] will be destroyed
  # (because key ["product-r-strategy-assistant"] is not in for_each map)
  - resource "vault_approle_auth_backend_role" "product-team-approles" {
      - backend                 = "approle" -> null
      - bind_secret_id          = true -> null
      - id                      = "auth/approle/role/product-r-strategy-assistant" -> null
      - role_id                 = "a0eb2a8f-1d66-7730-7852-5404c58e6de1" -> null
      - role_name               = "product-r-strategy-assistant" -> null
      - secret_id_bound_cidrs   = [] -> null
      - secret_id_num_uses      = 0 -> null
      - secret_id_ttl           = 0 -> null
      - token_bound_cidrs       = [] -> null
      - token_explicit_max_ttl  = 0 -> null
      - token_max_ttl           = 1800 -> null
      - token_no_default_policy = false -> null
      - token_num_uses          = 0 -> null
      - token_period            = 0 -> null
      - token_policies          = [
          - "product-r-strategy-assistant-ro",
        ] -> null
      - token_ttl               = 1200 -> null
      - token_type              = "default" -> null
    }

  # module.vault.vault_approle_auth_backend_role.product-team-approles["r-strategy-assistant"] will be created
  + resource "vault_approle_auth_backend_role" "product-team-approles" {
      + backend            = "approle"
      + bind_secret_id     = true
      + id                 = (known after apply)
      + role_id            = (known after apply)
      + role_name          = "r-strategy-assistant"
      + secret_id_num_uses = 0
      + secret_id_ttl      = 0
      + token_max_ttl      = 1800
      + token_num_uses     = 0
      + token_policies     = [
          + "r-strategy-assistant-ro",
        ]
      + token_ttl          = 1200
      + token_type         = "default"
    }

  # module.vault.vault_approle_auth_backend_role_secret_id.product-teams-approle-ids["product-r-strategy-assistant"] will be destroyed
  # (because key ["product-r-strategy-assistant"] is not in for_each map)
  - resource "vault_approle_auth_backend_role_secret_id" "product-teams-approle-ids" {
      - accessor  = "850376b6-66b7-d0c0-e037-7076981f9d89" -> null
      - backend   = "approle" -> null
      - cidr_list = [] -> null
      - id        = "backend=approle::role=product-r-strategy-assistant::accessor=850376b6-66b7-d0c0-e037-7076981f9d89" -> null
      - metadata  = jsonencode({}) -> null
      - role_name = "product-r-strategy-assistant" -> null
      - secret_id = (sensitive value)
    }

  # module.vault.vault_approle_auth_backend_role_secret_id.product-teams-approle-ids["r-strategy-assistant"] will be created
  + resource "vault_approle_auth_backend_role_secret_id" "product-teams-approle-ids" {
      + accessor          = (known after apply)
      + backend           = "approle"
      + id                = (known after apply)
      + role_name         = "r-strategy-assistant"
      + secret_id         = (sensitive value)
      + wrapping_accessor = (known after apply)
      + wrapping_token    = (sensitive value)
    }

  # module.vault.vault_generic_secret.product-team-avp-secrets["product-r-strategy-assistant"] will be destroyed
  # (because key ["product-r-strategy-assistant"] is not in for_each map)
  - resource "vault_generic_secret" "product-team-avp-secrets" {
      - data                = (sensitive value)
      - data_json           = (sensitive value)
      - delete_all_versions = false -> null
      - disable_read        = false -> null
      - id                  = "devsecops/avp-config/product-r-strategy-assistant" -> null
      - path                = "devsecops/avp-config/product-r-strategy-assistant" -> null
    }

  # module.vault.vault_generic_secret.product-team-avp-secrets["r-strategy-assistant"] will be created
  + resource "vault_generic_secret" "product-team-avp-secrets" {
      + data                = (sensitive value)
      + data_json           = (sensitive value)
      + delete_all_versions = false
      + disable_read        = false
      + id                  = (known after apply)
      + path                = "devsecops/avp-config/r-strategy-assistant"
    }

  # module.vault.vault_github_team.github-product-teams["item-relationship-service-frontend"] must be replaced
-/+ resource "vault_github_team" "github-product-teams" {
      ~ id       = "auth/github/map/teams/item-relationship-service-frontend" -> (known after apply)
      ~ team     = "item-relationship-service-frontend" -> "product-item-relationship-service-frontend" # forces replacement
        # (2 unchanged attributes hidden)
    }

  # module.vault.vault_github_team.github-product-teams["product-r-strategy-assistant"] will be destroyed
  # (because key ["product-r-strategy-assistant"] is not in for_each map)
  - resource "vault_github_team" "github-product-teams" {
      - backend  = "github" -> null
      - id       = "auth/github/map/teams/product-r-strategy-assistant" -> null
      - policies = [
          - "product-r-strategy-assistant-rw",
        ] -> null
      - team     = "product-r-strategy-assistant" -> null
    }

  # module.vault.vault_github_team.github-product-teams["r-strategy-assistant"] will be created
  + resource "vault_github_team" "github-product-teams" {
      + backend  = "github"
      + id       = (known after apply)
      + policies = [
          + "r-strategy-assistant-rw",
        ]
      + team     = "product-r-strategy-assistant"
    }

  # module.vault.vault_jwt_auth_backend_role.oidc_auth_roles["item-relationship-service-frontend"] must be replaced
-/+ resource "vault_jwt_auth_backend_role" "oidc_auth_roles" {
      - bound_audiences              = [] -> null
      ~ bound_claims                 = {
          ~ "groups" = "catenax-ng:item-relationship-service-frontend" -> "catenax-ng:product-item-relationship-service-frontend"
        }
      ~ bound_claims_type            = "string" -> (known after apply)
      ~ id                           = "auth/oidc/role/item-relationship-service-frontend" -> (known after apply)
      ~ role_name                    = "item-relationship-service-frontend" -> "product-item-relationship-service-frontend" # forces replacement
      - token_bound_cidrs            = [] -> null
      - token_explicit_max_ttl       = 0 -> null
      - token_max_ttl                = 0 -> null
      - token_no_default_policy      = false -> null
      - token_num_uses               = 0 -> null
      - token_period                 = 0 -> null
      - token_ttl                    = 0 -> null
        # (12 unchanged attributes hidden)
    }

  # module.vault.vault_jwt_auth_backend_role.oidc_auth_roles["product-r-strategy-assistant"] will be destroyed
  # (because key ["product-r-strategy-assistant"] is not in for_each map)
  - resource "vault_jwt_auth_backend_role" "oidc_auth_roles" {
      - allowed_redirect_uris        = [
          - "http://localhost:8250/oidc/callback",
          - "https://vault.demo.catena-x.net/ui/vault/auth/oidc/oidc/callback",
        ] -> null
      - backend                      = "oidc" -> null
      - bound_audiences              = [] -> null
      - bound_claims                 = {
          - "groups" = "catenax-ng:product-r-strategy-assistant"
        } -> null
      - bound_claims_type            = "string" -> null
      - clock_skew_leeway            = 0 -> null
      - disable_bound_claims_parsing = false -> null
      - expiration_leeway            = 0 -> null
      - id                           = "auth/oidc/role/product-r-strategy-assistant" -> null
      - not_before_leeway            = 0 -> null
      - oidc_scopes                  = [
          - "email",
          - "groups",
          - "openid",
        ] -> null
      - role_name                    = "product-r-strategy-assistant" -> null
      - role_type                    = "oidc" -> null
      - token_bound_cidrs            = [] -> null
      - token_explicit_max_ttl       = 0 -> null
      - token_max_ttl                = 0 -> null
      - token_no_default_policy      = false -> null
      - token_num_uses               = 0 -> null
      - token_period                 = 0 -> null
      - token_policies               = [
          - "product-r-strategy-assistant-rw",
        ] -> null
      - token_ttl                    = 0 -> null
      - token_type                   = "default" -> null
      - user_claim                   = "email" -> null
      - verbose_oidc_logging         = false -> null
    }

  # module.vault.vault_jwt_auth_backend_role.oidc_auth_roles["r-strategy-assistant"] will be created
  + resource "vault_jwt_auth_backend_role" "oidc_auth_roles" {
      + allowed_redirect_uris        = [
          + "http://localhost:8250/oidc/callback",
          + "https://vault.demo.catena-x.net/ui/vault/auth/oidc/oidc/callback",
        ]
      + backend                      = "oidc"
      + bound_claims                 = {
          + "groups" = "catenax-ng:product-r-strategy-assistant"
        }
      + bound_claims_type            = (known after apply)
      + clock_skew_leeway            = 0
      + disable_bound_claims_parsing = false
      + expiration_leeway            = 0
      + id                           = (known after apply)
      + not_before_leeway            = 0
      + oidc_scopes                  = [
          + "email",
          + "groups",
          + "openid",
        ]
      + role_name                    = "product-r-strategy-assistant"
      + role_type                    = "oidc"
      + token_policies               = [
          + "r-strategy-assistant-rw",
        ]
      + token_type                   = "default"
      + user_claim                   = "email"
      + verbose_oidc_logging         = false
    }

  # module.vault.vault_mount.product-team-secret-engines["product-r-strategy-assistant"] will be destroyed
  # (because key ["product-r-strategy-assistant"] is not in for_each map)
  - resource "vault_mount" "product-team-secret-engines" {
      - accessor                     = "kv_4715312d" -> null
      - audit_non_hmac_request_keys  = [] -> null
      - audit_non_hmac_response_keys = [] -> null
      - default_lease_ttl_seconds    = 0 -> null
      - description                  = "Secret engine for team product-r-strategy-assistant" -> null
      - external_entropy_access      = false -> null
      - id                           = "product-r-strategy-assistant" -> null
      - local                        = false -> null
      - max_lease_ttl_seconds        = 0 -> null
      - options                      = {
          - "version" = "2"
        } -> null
      - path                         = "product-r-strategy-assistant" -> null
      - seal_wrap                    = false -> null
      - type                         = "kv" -> null
    }

  # module.vault.vault_mount.product-team-secret-engines["r-strategy-assistant"] will be created
  + resource "vault_mount" "product-team-secret-engines" {
      + accessor                     = (known after apply)
      + audit_non_hmac_request_keys  = (known after apply)
      + audit_non_hmac_response_keys = (known after apply)
      + default_lease_ttl_seconds    = (known after apply)
      + description                  = "Secret engine for team r-strategy-assistant"
      + external_entropy_access      = false
      + id                           = (known after apply)
      + max_lease_ttl_seconds        = (known after apply)
      + options                      = {
          + "version" = "2"
        }
      + path                         = "r-strategy-assistant"
      + seal_wrap                    = (known after apply)
      + type                         = "kv"
    }

  # module.vault.vault_policy.product-approle-read-only-policies["product-r-strategy-assistant"] will be destroyed
  # (because key ["product-r-strategy-assistant"] is not in for_each map)
  - resource "vault_policy" "product-approle-read-only-policies" {
      - id     = "product-r-strategy-assistant-ro" -> null
      - name   = "product-r-strategy-assistant-ro" -> null
      - policy = <<-EOT
            path "product-r-strategy-assistant/*" {
              capabilities = [ "read" ]
            }
        EOT -> null
    }

  # module.vault.vault_policy.product-approle-read-only-policies["r-strategy-assistant"] will be created
  + resource "vault_policy" "product-approle-read-only-policies" {
      + id     = (known after apply)
      + name   = "r-strategy-assistant-ro"
      + policy = <<-EOT
            path "r-strategy-assistant/*" {
              capabilities = [ "read" ]
            }
        EOT
    }

  # module.vault.vault_policy.product-team-policies["product-r-strategy-assistant"] will be destroyed
  # (because key ["product-r-strategy-assistant"] is not in for_each map)
  - resource "vault_policy" "product-team-policies" {
      - id     = "product-r-strategy-assistant-rw" -> null
      - name   = "product-r-strategy-assistant-rw" -> null
      - policy = <<-EOT
            path "product-r-strategy-assistant/*" {
              capabilities = [ "create", "read", "update", "delete", "list" ]
            }
        EOT -> null
    }

  # module.vault.vault_policy.product-team-policies["r-strategy-assistant"] will be created
  + resource "vault_policy" "product-team-policies" {
      + id     = (known after apply)
      + name   = "r-strategy-assistant-rw"
      + policy = <<-EOT
            path "r-strategy-assistant/*" {
              capabilities = [ "create", "read", "update", "delete", "list" ]
            }
        EOT
    }

Plan: 10 to add, 0 to change, 10 to destroy.
````

`terraform apply` will be executed after PR is merged to main branch.