### PR TITLE
Bump ArgoCD Version to 2.3.11

### DIFF
--- a/apps/argocd/base/kustomization.yaml
+++ b/apps/argocd/base/kustomization.yaml
@@ -4,7 +4,7 @@ namespace: argocd
 
 resources:
   - namespace.yaml
-  - https://raw.githubusercontent.com/argoproj/argo-cd/v2.3.10/manifests/ha/install.yaml
+  - https://raw.githubusercontent.com/argoproj/argo-cd/v2.3.11/manifests/ha/install.yaml
   - rbac-secret-access.yaml # grant avp access to secret with AVP configuration
 
 patchesStrategicMerge:

--- a/environments/core/applicationsets/argo-applicationset.yaml
+++ b/environments/core/applicationsets/argo-applicationset.yaml
@@ -21,7 +21,7 @@ spec:
       - cluster: devsecops-testing
         cluster-name: devsecops-testing
         overlay: overlays/devsecops-testing
-        targetRevision: ArgoCD-v2.3.11_AVP-v0.13.0
+        targetRevision: ArgoCD-v2.3.11_AVP-v1.13.0
       - cluster: pre-prod
         cluster-name: pre-prod
         overlay: overlays/pre-prod

--- a/environments/core/applicationsets/argo-applicationset.yaml
+++ b/environments/core/applicationsets/argo-applicationset.yaml
@@ -21,7 +21,7 @@ spec:
       - cluster: devsecops-testing
         cluster-name: devsecops-testing
         overlay: overlays/devsecops-testing
-        targetRevision: ArgoCD-v2.3.10_AVP-v0.13.0
+        targetRevision: ArgoCD-v2.3.11_AVP-v0.13.0
       - cluster: pre-prod
         cluster-name: pre-prod
         overlay: overlays/pre-prod


### PR DESCRIPTION
Bump ArgoCD version to 2.3.11 due to fixed security vulnerabilities. Also fixed the AVP part of the `targetRevision` tag, it was named wrong (0.13.0 instead of installed 1.13.0).

New ArgoCD version only set for _devsecops-testing_ cluster for testing.

After merging to `main` branch, I'll create git tag `ArgoCD-v2.3.11_AVP-v1.13.0`