### PR TITLE
Rollout ArgoCD v2.3.11 to production

### DIFF
--- a/environments/core/applicationsets/argo-applicationset.yaml
+++ b/environments/core/applicationsets/argo-applicationset.yaml
@@ -9,15 +9,15 @@ spec:
       - cluster: core
         cluster-name: in-cluster
         overlay: overlays/core
-        targetRevision: ArgoCD-v2.3.10_AVP-v0.13.0
+        targetRevision: ArgoCD-v2.3.11_AVP-v1.13.0
       - cluster: hotel-budapest
         cluster-name: hotel-budapest
         overlay: overlays/hotel-budapest
-        targetRevision: ArgoCD-v2.3.10_AVP-v0.13.0
+        targetRevision: ArgoCD-v2.3.11_AVP-v1.13.0
       - cluster: dev
         cluster-name: dev
         overlay: overlays/dev
-        targetRevision: ArgoCD-v2.3.10_AVP-v0.13.0
+        targetRevision: ArgoCD-v2.3.11_AVP-v1.13.0
       - cluster: devsecops-testing
         cluster-name: devsecops-testing
         overlay: overlays/devsecops-testing
@@ -25,11 +25,11 @@ spec:
       - cluster: pre-prod
         cluster-name: pre-prod
         overlay: overlays/pre-prod
-        targetRevision: ArgoCD-v2.3.10_AVP-v0.13.0
+        targetRevision: ArgoCD-v2.3.11_AVP-v1.13.0
       - cluster: beta
         cluster-name: beta
         overlay: overlays/beta
-        targetRevision: ArgoCD-v2.3.10_AVP-v0.13.0
+        targetRevision: ArgoCD-v2.3.11_AVP-v1.13.0
 
   template:
     metadata:


### PR DESCRIPTION
Bumped `targetRevision` for production clusters in ArgoCD ApplicationSet.