### PR TITLE
chore: enable GH Pages for repo sd-hub for Chart releaser action

### DIFF
--- a/terraform/100_team_onboarding/main.tf
+++ b/terraform/100_team_onboarding/main.tf
@@ -668,8 +668,8 @@ module "github" {
       homepage_url : ""
       topics : []
       pages : {
-        enabled : false
-        branch : "main"
+        enabled : true
+        branch : "gh-pages"
       }
       is_template : false
       uses_template : false


### PR DESCRIPTION
Enable GH Pages for proper useage of Chart Releaser action.

`Terraform plan` looks pretty good:

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.github.github_repository.repositories["product-sd-hub"] will be updated in-place
  ~ resource "github_repository" "repositories" {
        id                          = "product-sd-hub"
        name                        = "product-sd-hub"
        # (30 unchanged attributes hidden)

      + pages {
          + source {
              + branch = "gh-pages"
              + path   = "/"
            }
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

`terraform apply` will be applied after merging to `main` branch.