### PR TITLE
chore: add tx-portal-assets fork repo

### DIFF
--- a/terraform/100_team_onboarding/.terraform.lock.hcl
+++ b/terraform/100_team_onboarding/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.30.0"
   constraints = ">= 2.99.0"
   hashes = [
+    "h1:Yf4/Lnus9CU8BlcWJN4MSaKaR67zl6WscY60Rcbu3TM=",
     "h1:bE2wEqpDqfjwxpOq3ff0Qhf6FEfB+epFuxeZBNCuQz4=",
     "h1:qTc2l8R3gABDAasdHeoayT1LauuAEuOiPkEiittW0uI=",
     "zh:015fa497bbb738dc704843ee421c79b40140919acc7301a480f645ebb2359475",
@@ -26,6 +27,7 @@ provider "registry.terraform.io/hashicorp/github" {
   version = "5.7.0"
   hashes = [
     "h1:Izwxsn2PaUji/REa6FM5+kN7kHN0pDtVlRfpRsdpJf4=",
+    "h1:it8faA/RfAwPrCktB+AELdhqynSEPzEmWzpgrpYmcXE=",
     "h1:yxFoLEBm40d/38RN2JB0Aw7uapOrDnh9m8nsDTgI7UI=",
     "zh:10dbf885c13f1ebb0cebaa81da2febcdf1cd2aa6d96506fbae46e79c066bd38c",
     "zh:1911db0547a5d8bf299747854dec6ba6d11f0122d1706c772ceb0e59c8129e19",
@@ -71,6 +73,7 @@ provider "registry.terraform.io/integrations/github" {
   constraints = "5.7.0"
   hashes = [
     "h1:Izwxsn2PaUji/REa6FM5+kN7kHN0pDtVlRfpRsdpJf4=",
+    "h1:it8faA/RfAwPrCktB+AELdhqynSEPzEmWzpgrpYmcXE=",
     "h1:yxFoLEBm40d/38RN2JB0Aw7uapOrDnh9m8nsDTgI7UI=",
     "zh:10dbf885c13f1ebb0cebaa81da2febcdf1cd2aa6d96506fbae46e79c066bd38c",
     "zh:1911db0547a5d8bf299747854dec6ba6d11f0122d1706c772ceb0e59c8129e19",

--- a/terraform/100_team_onboarding/main.tf
+++ b/terraform/100_team_onboarding/main.tf
@@ -669,7 +669,7 @@ module "github" {
       topics : []
       pages : {
         enabled : true
-        branch : "main"
+        branch : "gh-pages"
       }
       is_template : false
       uses_template : false

--- a/terraform/100_team_onboarding/main.tf
+++ b/terraform/100_team_onboarding/main.tf
@@ -669,7 +669,7 @@ module "github" {
       topics : []
       pages : {
         enabled : true
-        branch : "gh-pages"
+        branch : "main"
       }
       is_template : false
       uses_template : false
@@ -1546,6 +1546,23 @@ module "github" {
       codeowners_available : false
       codeowners : null
     },
+    "tx-portal-assets" : {
+      name : "tx-portal-assets"
+      team_name : "product-portal"
+      description : "Catena-X Portal Assets"
+      visibility : "public"
+      homepage_url : ""
+      topics : []
+      pages : {
+        enabled : false
+        branch : ""
+      }
+      is_template : false
+      uses_template : false
+      template : null
+      codeowners_available : false
+      codeowners : null
+    },
     "tx-portal-frontend-registration" : {
       name : "tx-portal-frontend-registration"
       team_name : "product-portal"
@@ -1938,6 +1955,11 @@ module "github" {
       team_name : "product-portal"
       repository : "catena-x-release-deployment"
       permission : "push"
+    },
+    "tx-portal-assets-product-portal" : {
+      team_name : "product-portal"
+      repository : "tx-portal-assets"
+      permission : "maintain"
     },
     "tx-portal-frontend-registration-product-portal" : {
       team_name : "product-portal"


### PR DESCRIPTION
- Forking https://github.com/eclipse-tractusx/portal-assets to catenax-ng/tx-portal-assets
- Changing product-sd-hub page branch to `main` as they use Pages for documentation instead of Helm repo

`terraform plan` output:

```plan
Terraform will perform the following actions:

  # module.github.github_repository.repositories["product-sd-hub"] will be updated in-place
  ~ resource "github_repository" "repositories" {
        id                          = "product-sd-hub"
        name                        = "product-sd-hub"
        # (30 unchanged attributes hidden)

      ~ pages {
            # (1 unchanged attribute hidden)

          ~ source {
              ~ branch = "main" -> "gh-pages"
                # (1 unchanged attribute hidden)
            }
        }
    }

  # module.github.github_repository.repositories["tx-portal-assets"] will be updated in-place
  ~ resource "github_repository" "repositories" {
      ~ auto_init                   = false -> true
        id                          = "tx-portal-assets"
        name                        = "tx-portal-assets"
        # (31 unchanged attributes hidden)
    }

  # module.github.github_team_repository.team-repository-access["tx-portal-assets-product-portal"] will be created
  + resource "github_team_repository" "team-repository-access" {
      + etag       = (known after apply)
      + id         = (known after apply)
      + permission = "maintain"
      + repository = "tx-portal-assets"
      + team_id    = "5784328"
    }

Plan: 1 to add, 2 to change, 0 to destroy.
```