### PR TITLE
fix: add rolebinding to argocd-repo-server user

### DIFF
--- a/apps/argocd/base/rbac-secret-access.yaml
+++ b/apps/argocd/base/rbac-secret-access.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: argocd-access-secret
+  name: argocd-default-access-secret
   namespace: argocd
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -10,6 +10,20 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: default
+    namespace: argocd
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argocd-argocd-repo-server-access-secret
+  namespace: argocd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argocd-access-secret
+subjects:
+  - kind: ServiceAccount
+    name: argocd-repo-server
     namespace: argocd
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
In ArgoCD 2.4 a new `ServiceAccount` was introduced: https://github.com/argoproj/argo-cd/pull/9301
This would break the AVP plugin as the new `ServiceAccount` does not have get access to `Secrets` in argocd namespace. Adding new `RoleBinding` to this account would solve the access issue.
ArgoCD issue with possible solution: https://github.com/argoproj/argo-cd/issues/10499#issuecomment-1315917334

I've also left the `RoleBinding` for the default `ServiceAccount` to avoid compatibility issues.