### PR TITLE
feat: change targetrevision for all clusters

### DIFF
--- a/environments/core/applicationsets/argo-applicationset.yaml
+++ b/environments/core/applicationsets/argo-applicationset.yaml
@@ -9,15 +9,15 @@ spec:
       - cluster: core
         cluster-name: in-cluster
         overlay: overlays/core
-        targetRevision: ArgoCD-v2.3.11_AVP-v1.13.0
+        targetRevision: ArgoCD-v2.4.16_AVP-v1.13.0
       - cluster: hotel-budapest
         cluster-name: hotel-budapest
         overlay: overlays/hotel-budapest
-        targetRevision: ArgoCD-v2.3.11_AVP-v1.13.0
+        targetRevision: ArgoCD-v2.4.16_AVP-v1.13.0
       - cluster: dev
         cluster-name: dev
         overlay: overlays/dev
-        targetRevision: ArgoCD-v2.3.11_AVP-v1.13.0
+        targetRevision: ArgoCD-v2.4.16_AVP-v1.13.0
       - cluster: devsecops-testing
         cluster-name: devsecops-testing
         overlay: overlays/devsecops-testing
@@ -25,11 +25,11 @@ spec:
       - cluster: pre-prod
         cluster-name: pre-prod
         overlay: overlays/pre-prod
-        targetRevision: ArgoCD-v2.3.11_AVP-v1.13.0
+        targetRevision: ArgoCD-v2.4.16_AVP-v1.13.0
       - cluster: beta
         cluster-name: beta
         overlay: overlays/beta
-        targetRevision: ArgoCD-v2.3.11_AVP-v1.13.0
+        targetRevision: ArgoCD-v2.4.16_AVP-v1.13.0
 
   template:
     metadata:

--- a/environments/core/applicationsets/argo-applicationset.yaml
+++ b/environments/core/applicationsets/argo-applicationset.yaml
@@ -21,7 +21,7 @@ spec:
       - cluster: devsecops-testing
         cluster-name: devsecops-testing
         overlay: overlays/devsecops-testing
-        targetRevision: HEAD
+        targetRevision: HEAD # intentional for testing purposes, don't change without good reason
       - cluster: pre-prod
         cluster-name: pre-prod
         overlay: overlays/pre-prod


### PR DESCRIPTION
change TargetRevision to tag ArgoCD-v2.4.16_AVP-v1.13.0

Draft until [this PR](https://github.com/catenax-ng/k8s-cluster-stack/pull/245) is approved as it is related.