### PR TITLE
chore: onboard managed-identity-wallet beta env

### DIFF
--- a/environments/beta/argo-projects/product-managed-identity-wallets.yaml
+++ b/environments/beta/argo-projects/product-managed-identity-wallets.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: product-managed-identity-wallets
+---
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: project-managed-identity-wallets
+  namespace: argocd
+spec:
+  description: Project for team managed identity wallets.
+  sourceRepos:
+    - '*'
+  destinations:
+    - namespace: product-managed-identity-wallets
+      server: https://kubernetes.default.svc
+  # Allow all namespaced-scoped resources to be created, except for ResourceQuota, LimitRange, NetworkPolicy
+  namespaceResourceBlacklist:
+    - group: ''
+      kind: ResourceQuota
+    - group: ''
+      kind: LimitRange
+    - group: ''
+      kind: NetworkPolicy
+  roles:
+    # A role which provides access to all applications in the project
+    - name: team-admin
+      description: All access to applications inside project-managed-identity-wallets. Read only on project itself
+      policies:
+        - p, proj:project-managed-identity-wallets:team-admin, applications, *, project-managed-identity-wallets/*, allow
+        - p, proj:project-managed-identity-wallets:team-admin, exec, create, project-managed-identity-wallets/*, allow
+      groups:
+        - catenax-ng:product-managed-identity-wallets

--- a/environments/beta/avp-secrets/managed-identity-wallets-team-vault-secret.yaml
+++ b/environments/beta/avp-secrets/managed-identity-wallets-team-vault-secret.yaml
@@ -1,0 +1,16 @@
+# To onboard a new product team,replace TEAM-NAME with name of team in line 7-9
+# Save as TEAM-NAME-team-vault-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    avp.kubernetes.io/path: "devsecops/data/avp-config/managed-identity-wallets"
+  name: vault-secret
+  namespace: product-managed-identity-wallets
+type: Opaque
+stringData:
+  VAULT_ADDR: https://vault.demo.catena-x.net/
+  AVP_TYPE: vault
+  AVP_AUTH_TYPE: approle
+  AVP_ROLE_ID: <role_id>
+  AVP_SECRET_ID: <secret_id>

--- a/environments/beta/kustomization.yaml
+++ b/environments/beta/kustomization.yaml
@@ -25,6 +25,9 @@ resources:
   
   - argo-projects/product-traceability-irs.yaml
   - avp-secrets/traceablity-irs-team-vault-secret.yaml
+  
+  - argo-projects/product-managed-identity-wallets.yaml
+  - avp-secrets/managed-identity-wallets-team-vault-secret.yaml
 
   - avp-secrets/devsecops-team-vault-secret.yaml
 


### PR DESCRIPTION
Team requested `argo project` and access to the `beta environment`. See chat on the [CoP Channel](https://teams.microsoft.com/l/message/19:9a3c4a05a3514d07b973c13e7b468709@thread.tacv2/1669304281942?tenantId=1ad22c6d-2f08-4f05-a0ba-e17f6ce88380&groupId=17b1a2dc-67fb-4a49-a2ed-dd1344321439&parentMessageId=1669304281942&teamName=Communities%20of%20Practices&channelName=CX%20-%20CoP%20DevSecOps&createdTime=1669304281942&allowXTenantAccess=false).

- argo project added on beta env
- vault secret added for team on beta env