### PR TITLE
fix: argocd 2.4 env variable breaking change

### DIFF
--- a/apps/argocd/base/avp-argocd-cm.yaml
+++ b/apps/argocd/base/avp-argocd-cm.yaml
@@ -21,7 +21,7 @@ data:
         args: ["helm dependency update -n $ARGOCD_APP_NAMESPACE"]
       generate:
         command: ["sh", "-c"]
-        args: ["helm template $ARGOCD_APP_NAME -n $ARGOCD_APP_NAMESPACE ${helm_args} . | argocd-vault-plugin generate - -s vault-secret"]
+        args: ["helm template $ARGOCD_APP_NAME -n $ARGOCD_APP_NAMESPACE ${ARGOCD_ENV_helm_args} . | argocd-vault-plugin generate - -s vault-secret"]
     - name: argocd-vault-plugin-kustomize
       generate:
         command: ["sh", "-c"]
@@ -32,4 +32,4 @@ data:
           args: ["helm dependency update -n $ARGOCD_APP_NAMESPACE"]
       generate:
         command: ["sh", "-c"]
-        args: ["helm template $ARGOCD_APP_NAME -n $ARGOCD_APP_NAMESPACE ${helm_args} . > manifest.yaml && kustomize build | argocd-vault-plugin generate - -s vault-secret"]
+        args: ["helm template $ARGOCD_APP_NAME -n $ARGOCD_APP_NAMESPACE ${ARGOCD_ENV_helm_args} . > manifest.yaml && kustomize build | argocd-vault-plugin generate - -s vault-secret"]

--- a/environments/core/applicationsets/argo-applicationset.yaml
+++ b/environments/core/applicationsets/argo-applicationset.yaml
@@ -21,7 +21,7 @@ spec:
       - cluster: devsecops-testing
         cluster-name: devsecops-testing
         overlay: overlays/devsecops-testing
-        targetRevision: fix/argo_2.4_env_variable_breaking_change # intentional for testing purposes, don't change without good reason
+        targetRevision: HEAD # intentional for testing purposes, don't change without good reason
       - cluster: pre-prod
         cluster-name: pre-prod
         overlay: overlays/pre-prod


### PR DESCRIPTION
ArgoCD 2.4 introduces an automatic prefix for user supplied environment variables. This applies to custom plugin configurations that we currently have. Therefore the `helm_args` variable we use with the AVP plugin does not work and therefore custom values.yaml files cannot be applied to the deployment.

Plans to fix and test:

1. Already [added an app](https://argo.devsecops-testing.demo.catena-x.net/applications/product-traceability-foss-frontend?view=tree&resource=) to the `devsecops-testing` cluster and it is showing no resources (as intended).
2. Point `devsecops-testing` argo config to this branch and enable the changes I made
3. Sync the app again and see if the problems are fixed
4. Point `devsecops-testing` back to the original branch
5. Merge and apply changes to all clusters

TEST RESULTS:
- Deployed application resources appeared and sync was successful after applying the changes to the `devsecops-testing` cluster
- Deployed another app where `vault` secrets were referenced in the `vaules-dev.yaml` file. Secrets synced successfully with proper content

Based on the following discussions/arcles:

- https://argo-cd.readthedocs.io/en/latest/operator-manual/upgrading/2.3-2.4/#update-plugins-to-use-newly-prefixed-environment-variables
- https://github.com/argoproj/argo-cd/discussions/9814#discussioncomment-3044394
- https://blog.argoproj.io/breaking-changes-in-argo-cd-2-4-29e3c2ac30c9