### PR TITLE
fix: set deprecated repo to read only

### DIFF
--- a/terraform/100_team_onboarding/main.tf
+++ b/terraform/100_team_onboarding/main.tf
@@ -1852,7 +1852,7 @@ module "github" {
     "product-portal-frontend-registration-product-portal" : {
       team_name : "product-portal"
       repository : "product-portal-frontend-registration"
-      permission : "push"
+      permission : "pull"
     },
     "product-edc-product-edc" : {
       team_name : "product-edc"


### PR DESCRIPTION
repo "product-portal-frontend-registration" was replaced by "tx-portal-frontend-registration" and should therefore be read only too