### PR TITLE
Onboard new GitHub Team + New repository (2x) A1ODT-1083

### DIFF
--- a/terraform/100_team_onboarding/main.tf
+++ b/terraform/100_team_onboarding/main.tf
@@ -14,6 +14,15 @@ module "vault" {
       avp_secret_name : "example"
       github_team : "product-team-example"
     },
+    "puris" : {
+      name : "puris",
+      secret_engine_name : "puris"
+      ui_policy_name : "puris-rw"
+      approle_name : "puris"
+      approle_policy_name : "puris-ro"
+      avp_secret_name : "puris"
+      github_team : "product-puris"
+    },
     "edc" : {
       name : "edc",
       secret_engine_name : "edc"
@@ -244,6 +253,10 @@ module "github" {
       "name" : "argocdadmins",
       "description" : "ArgoCD OAuth administrator team"
     },
+    "product-puris" : {
+      "name" : "product-puris",
+      "description" : "Product Team puris"
+    },
     "cx-core-schemas" : {
       "name" : "cx-core-schemas",
       "description" : ""
@@ -371,6 +384,48 @@ module "github" {
   }
 
   github_repositories = {
+    "product-puris-backend" : {
+      name : "product-puris-backend"
+      team_name : "product-puris"
+      description : ""
+      visibility : "public"
+      homepage_url : ""
+      topics : []
+      pages : {
+        enabled : true
+        branch : "gh-pages"
+      }
+      is_template : false
+      uses_template : false
+      template : {
+        owner : "catenax-ng"
+        repository : "k8s-helm-example"
+      }
+      codeowners_available : false
+      codeowners : null
+
+    },
+    "product-puris-frontend" : {
+      name : "product-puris-frontend"
+      team_name : "product-puris"
+      description : ""
+      visibility : "public"
+      homepage_url : ""
+      topics : []
+      pages : {
+        enabled : true
+        branch : "gh-pages"
+      }
+      is_template : false
+      uses_template : false
+      template : {
+        owner : "catenax-ng"
+        repository : "k8s-helm-example"
+      }
+      codeowners_available : false
+      codeowners : null
+
+    },
     "product-bpdm" : {
       name : "product-bpdm"
       team_name : "product-bpdm"
@@ -1531,14 +1586,14 @@ module "github" {
     "tx-item-relationship-service" : {
       name : "tx-item-relationship-service"
       team_name : "product-traceability-irs"
-      homepage_url: "https://catenax-ng.github.io/tx-item-relationship-service/docs/"
+      homepage_url : "https://catenax-ng.github.io/tx-item-relationship-service/docs/"
       description : ""
       visibility : "public"
       homepage_url : "https://catenax-ng.github.io/tx-item-relationship-service/docs/"
       topics : []
       pages : {
         enabled : true
-        branch: "gh-pages"
+        branch : "gh-pages"
       }
       is_template : false
       uses_template : false
@@ -1603,7 +1658,7 @@ module "github" {
       description : "Catena-X Portal Frontend Registration"
       visibility : "public"
       homepage_url : "https://portal.demo.catena-x.net/registration/"
-      topics : [ "catena-x", "frontend", "portal", "registration"]
+      topics : ["catena-x", "frontend", "portal", "registration"]
       pages : {
         enabled : false
         branch : ""

--- a/terraform/100_team_onboarding/main.tf
+++ b/terraform/100_team_onboarding/main.tf
@@ -1812,6 +1812,16 @@ module "github" {
 
   github_repositories_teams = {
     # repoName-gh-teamName
+    "product-puris-backend-product-puris" : {
+      team_name : "product-puris"
+      repository : "product-puris-backend"
+      permission : "maintain"
+    },
+    "product-puris-frontend-product-puris" : {
+      team_name : "product-puris"
+      repository : "product-puris-frontend"
+      permission : "maintain"
+    },
     "product-bpdm-product-bpdm" : {
       team_name : "product-bpdm"
       repository : "product-bpdm"


### PR DESCRIPTION
Adding new team puris and two gh repositories.

repository names: 
- product-puris-frontend
-  product-puris-backend

See https://jira.catena-x.net/browse/A1ODT-1083

`terraform apply` not performed, will be done after PR approval. `terraform plan` behave as expected:

```
Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the last "terraform apply" which may have affected this plan:

  # module.github.github_team.teams["argocdadmins"] has changed
  ~ resource "github_team" "teams" {
      ~ etag          = "W/\"b2302ec9be04aa91939d55ecf17b5216d1d7ffa2b2e5e020018c82d196ea9891\"" -> "W/\"0bef818a7faf25d0f14052289a21d9ec8a64cb0ab24a1dcd2aa52a1b703d08a3\""
        id            = "5765033"
        name          = "argocdadmins"
        # (5 unchanged attributes hidden)
    }

  # module.github.github_team.teams["cx-core-schemas"] has changed
  ~ resource "github_team" "teams" {
      ~ etag          = "W/\"f3777cdc190c893a30dc5bba0ada0bfed4dad21925b4362487ad3bad02cf854a\"" -> "W/\"12c76f04cecb71c9d1420ec5a136b2fd3a9bea94e860c55519775e007345bc67\""
        id            = "5891644"
        name          = "cx-core-schemas"
        # (4 unchanged attributes hidden)
    }

  # module.github.github_team.teams["product-behaviour-twin-pilot"] has changed
  ~ resource "github_team" "teams" {
      ~ etag          = "W/\"31024fb2049c18dbb7c56aad9e1916e3d864298726e4d8055d640f99f5a794ff\"" -> "W/\"e47b08b904af5005fd7333ecc9e38760927908b14516c37dd5f45b1bdf303faa\""
        id            = "6177751"
        name          = "product-behaviour-twin-pilot"
        # (4 unchanged attributes hidden)
    }

  # module.github.github_team.teams["product-bpdm"] has changed
  ~ resource "github_team" "teams" {
      ~ etag          = "W/\"269b49f09bdb13a44e6f1c2d9795161aca420ce1412f3128e0e80813a66ec362\"" -> "W/\"a488820091e2842bb4fa18785a73f29f82c744d544b5d1f7815504fbe9fce4a3\""
        id            = "5788667"
        name          = "product-bpdm"
        # (4 unchanged attributes hidden)
    }

  # module.github.github_team.teams["product-business-partner-certificates"] has changed
  ~ resource "github_team" "teams" {
      ~ etag                      = "W/\"c8ac532d1993b19755e053a98de73a52804c3ece9a17400ad7258ad8c8c6bef8\"" -> "W/\"6f5a7c4716998d92ade9ca02dd9fef18ff9f3b9576de09d054de77f1ed7dd5f3\""
        id                        = "6710860"
        name                      = "product-business-partner-certificates"
        # (5 unchanged attributes hidden)
    }

  # module.github.github_team.teams["product-catenax-at-home"] has changed
  ~ resource "github_team" "teams" {
      ~ etag          = "W/\"514e505762be724fd761df2fe8e4ed3452902f344fdd70e818768d5bf27af66b\"" -> "W/\"ec1692575855ade16f4faedfe9acf7277f64a5d910158030d26bd7ccc7558d8b\""
        id            = "5953422"
        name          = "product-catenax-at-home"
        # (4 unchanged attributes hidden)
    }

  # module.github.github_team.teams["product-data-integrity-demonstrator"] has changed
  ~ resource "github_team" "teams" {
      ~ etag          = "W/\"75c924a695c1f6adbc6498ac0e7643bfc917df05312befa8eddf86fee97560b5\"" -> "W/\"6d42bc05a04aeb76b42f4a10fe005f939a511dcdf299afebb116482c5c42f17b\""
        id            = "5862410"
        name          = "product-data-integrity-demonstrator"
        # (4 unchanged attributes hidden)
    }

  # module.github.github_team.teams["product-dft"] has changed
  ~ resource "github_team" "teams" {
      ~ etag          = "W/\"fa0d123b85552f978bad219efbbc6a036a1cafc852a126e376f62ba5befd6a83\"" -> "W/\"149ade24fdd7ad47f2df226652dea2ba4285c456bf78b3df51081b5f9dc2bceb\""
        id            = "5917337"
        name          = "product-dft"
        # (4 unchanged attributes hidden)
    }

  # module.github.github_team.teams["product-edc"] has changed
  ~ resource "github_team" "teams" {
      ~ etag          = "W/\"e5e8d467816810fd7a1579bab4b0f995a92d14970c68ee51049fa570a07585d8\"" -> "W/\"352bdd5fdaa17f14d1f091a291a9ccaead031fb3e24a11869f20b7d8242844e2\""
        id            = "5788757"
        name          = "product-edc"
        # (4 unchanged attributes hidden)
    }

  # module.github.github_team.teams["product-esc-backbone"] has changed
  ~ resource "github_team" "teams" {
      ~ etag          = "W/\"05a02df4c083381a7422a00437b2f4527609b0a64b8cd5c31005fd6d516f7ee9\"" -> "W/\"1e7ba801fbecdf3e74fa54813d74501bf4e4c0707fee4cbe550c064db9a83c82\""
        id            = "5886155"
        name          = "product-esc-backbone"
        # (4 unchanged attributes hidden)
    }

  # module.github.github_team.teams["product-essential-services"] has changed
  ~ resource "github_team" "teams" {
      ~ etag          = "W/\"d8646e27166d92bedaf6937d614e779c0c1ca20b60fe098c6dfc67711dc21dc4\"" -> "W/\"919a25a3f8153ee1edeea6c988cafbb1777321253e19e664b1e608c5ebb59ec0\""
        id            = "5788681"
        name          = "product-essential-services"
        # (4 unchanged attributes hidden)
    }

  # module.github.github_team.teams["product-et-demonstrators"] has changed
  ~ resource "github_team" "teams" {
      ~ etag                      = "W/\"e7c28a88f8b1881a48fec323f687eeabf54d14e3f6fbed8e191e11ff98b64d6a\"" -> "W/\"5428cde255a14871094b4f839d8b8c160127836d0511c9cf5fc25368b0cc6f9d\""
        id                        = "6710861"
        name                      = "product-et-demonstrators"
        # (5 unchanged attributes hidden)
    }

  # module.github.github_team.teams["product-explorer"] has changed
  ~ resource "github_team" "teams" {
      ~ etag          = "W/\"b1275e5a8b06b9ec9128e879c0d128b1fda9a10dde7040802eedb2864d3e98f8\"" -> "W/\"b7f87c3d058995d463db5e893141a71de0e1c4e36ccc5ff24a21324ccf096739\""
        id            = "6132465"
        name          = "product-explorer"
        # (4 unchanged attributes hidden)
    }

  # module.github.github_team.teams["product-innovation-radar"] has changed
  ~ resource "github_team" "teams" {
      ~ etag                      = "W/\"a20213bfb06c862c31545eb7afeed4860b9160375226b1909a53aa8a7b7125fe\"" -> "W/\"848956772e1c6d4ec29c5ddbfd99a3959215e36f0432385956ebbff631e9f7b0\""
        id                        = "6441827"
        name                      = "product-innovation-radar"
        # (5 unchanged attributes hidden)
    }

  # module.github.github_team.teams["product-item-relationship-service-frontend"] has changed
  ~ resource "github_team" "teams" {
      ~ etag                      = "W/\"395dd31d4ada788106469b1b9007ea9aea941bfc87b0c4fbaa02132a26cef44c\"" -> "W/\"5f0fb1c52c63cebc1adc166d0a54b1ef09c91e58ab76ced401e701a8e7f6df92\""
        id                        = "6782704"
        name                      = "product-item-relationship-service-frontend"
        # (5 unchanged attributes hidden)
    }

  # module.github.github_team.teams["product-knowledge"] has changed
  ~ resource "github_team" "teams" {
      ~ etag          = "W/\"4751d358a54869d87d61369074c31e7504242d4eae4953e0decf80c6a74f98e3\"" -> "W/\"c5915b624bbf9bfb4896b0eea744ea7ea852b0b5813a2ffe61c138b8bcf8241d\""
        id            = "6237784"
        name          = "product-knowledge"
        # (5 unchanged attributes hidden)
    }

  # module.github.github_team.teams["product-managed-identity-wallets"] has changed
  ~ resource "github_team" "teams" {
      ~ etag          = "W/\"928094469b7108245f919805691e2bcf3e43f13661dbf68993325d61f7ef61cd\"" -> "W/\"d9d38f94f112353a54ae02343c6f75ecf7886f464e0ccf46b692090692e09826\""
        id            = "5795900"
        name          = "product-managed-identity-wallets"
        # (4 unchanged attributes hidden)
    }

  # module.github.github_team.teams["product-material-pass"] has changed
  ~ resource "github_team" "teams" {
      ~ etag          = "W/\"a51e13d136fe2a951fe0353ac32d6a3599a3b692dc2d417ece1c5110e39a04d0\"" -> "W/\"65c1ef7986e7d11ccac272b9e2f37fa70d056ec655a3163dbfe4410b80607bea\""
        id            = "5782916"
        name          = "product-material-pass"
        # (4 unchanged attributes hidden)
    }

  # module.github.github_team.teams["product-portal"] has changed
  ~ resource "github_team" "teams" {
      ~ etag          = "W/\"05c32dda2c1313dacef6b1807ee8fd7201c2e717e93f75a94255aa3548ff8326\"" -> "W/\"50a2d041cf6ee8fc6b4b3be7b0250548195faa74d9d51400cc1bde62573de273\""
        id            = "5784328"
        name          = "product-portal"
        # (4 unchanged attributes hidden)
    }

  # module.github.github_team.teams["product-r-strategy-assistant"] has changed
  ~ resource "github_team" "teams" {
      ~ etag                      = "W/\"2e2996233dc5db7e02e453f5316b2abae9da02474fe84a06b167a35d15b2a495\"" -> "W/\"7434a980c2a62e78e72d3a71c2da4e5474ddd9e0023c45470fef450988ab1a33\""
        id                        = "6886092"
        name                      = "product-r-strategy-assistant"
        # (5 unchanged attributes hidden)
    }

  # module.github.github_team.teams["product-registry-twin-check"] has changed
  ~ resource "github_team" "teams" {
      ~ etag                      = "W/\"32203d82906ec21a3c8d3c4e67402aa33cee8c214c50ef3c1e5bab0c585b8a65\"" -> "W/\"14b5dc77e551e992a8920b1b3b7175c17a34a9e164a2bba70d179d9c7006b921\""
        id                        = "6508737"
        name                      = "product-registry-twin-check"
        # (5 unchanged attributes hidden)
    }

  # module.github.github_team.teams["product-semantics"] has changed
  ~ resource "github_team" "teams" {
      ~ etag          = "W/\"fd8d9994af0e1b2544ada021a2827ff1031dd7e99618f00b7313c7a20bbefe47\"" -> "W/\"884dd236223b6aef9f5ec6782c88a3e273f0bb0d9c26feac4a765f8ed094d053\""
        id            = "5788670"
        name          = "product-semantics"
        # (4 unchanged attributes hidden)
    }

  # module.github.github_team.teams["product-team-example"] has changed
  ~ resource "github_team" "teams" {
      ~ etag          = "W/\"9a6b6b4e8478aec14319244373de640c665b3708a3f5c4f3982988ad76fc1e6f\"" -> "W/\"27475a72c33b4b076ef4faa17aeab03955f119a69621723802e85ac98a43c823\""
        id            = "5953783"
        name          = "product-team-example"
        # (5 unchanged attributes hidden)
    }

  # module.github.github_team.teams["product-test-data-generator"] has changed
  ~ resource "github_team" "teams" {
      ~ etag          = "W/\"bcfb043a7d2b5766a5414c607404bdad1d1991c89b1e8837baabf60cd83313a6\"" -> "W/\"f9e299b2e36c01e606b96a10c454193332efd78bc47bbe948e4b716072e83798\""
        id            = "5958135"
        name          = "product-test-data-generator"
        # (4 unchanged attributes hidden)
    }

  # module.github.github_team.teams["product-traceability-foss"] has changed
  ~ resource "github_team" "teams" {
      ~ etag          = "W/\"faf5d9cc019806fdac0ba226ddbf1174e0e96b01de1c2c8f0f5a2a76253bfaca\"" -> "W/\"e1572e8e91f500b7861e2e2f6d2a46c32169bff5b595b39554e3843c98796397\""
        id            = "5993975"
        name          = "product-traceability-foss"
        # (4 unchanged attributes hidden)
    }

  # module.github.github_team.teams["product-traceability-irs"] has changed
  ~ resource "github_team" "teams" {
      ~ etag          = "W/\"f01e915f604584db0455aba9937aa656a3719a76aef425caf0220988bd7d87fd\"" -> "W/\"2a67461f36d27a1d711052218a4c74288519974c2b836ed19e657a5fa57ca07f\""
        id            = "5783013"
        name          = "product-traceability-irs"
        # (4 unchanged attributes hidden)
    }

  # module.github.github_team.teams["product-value-added-service"] has changed
  ~ resource "github_team" "teams" {
      ~ etag          = "W/\"fcbce1e930f6edf63eb4a7e07d5f3f930bf2171d7b53a3d791b6ad1559d2e2a2\"" -> "W/\"8c3312922c1230460e44b91e5f4224a5c095271ea6479b0b849cbd8ef482421c\""
        id            = "6192065"
        name          = "product-value-added-service"
        # (4 unchanged attributes hidden)
    }

  # module.github.github_team.teams["release-management"] has changed
  ~ resource "github_team" "teams" {
      ~ etag                      = "W/\"dc0c515137f3646f3f744415625b87b8c0f19d36327a348208bb5b695832b413\"" -> "W/\"5bd957817326ca071b8a0b96f320bfd85f4f8eebcca900a2c0b69c527a190c78\""
        id                        = "6386785"
        name                      = "release-management"
        # (6 unchanged attributes hidden)
    }

  # module.github.github_team.teams["team-foss"] has changed
  ~ resource "github_team" "teams" {
      ~ etag          = "W/\"a7e32b90137ba0037237c0c363e726113346547b8535389aecc21464b553f5db\"" -> "W/\"db41c825ca808e62ff671e525c259f0e3f3d3b3b0d16ddf9cdefe2759472e877\""
        id            = "6192227"
        name          = "team-foss"
        # (5 unchanged attributes hidden)
    }

  # module.github.github_team.teams["team-hello-gitops"] has changed
  ~ resource "github_team" "teams" {
      ~ etag          = "W/\"5670bd5e3ba4eafc554a3f2816271308f62d61bff105eb896abdecf05bed8bdf\"" -> "W/\"0e5a236747be01a35aee90edc844aa474863743a34e8048998b77a5c3b8aa2fe\""
        id            = "5773880"
        name          = "team-hello-gitops"
        # (5 unchanged attributes hidden)
    }

  # module.github.github_team.teams["team-security"] has changed
  ~ resource "github_team" "teams" {
      ~ etag          = "W/\"7278ab829863e5a63a0b4c57e7c6cdfc9a4ae397434ba2890b7e5d993d8f9949\"" -> "W/\"0b1a7c8656a9039e6b7b1a19f17f6b61ef11471868689bb69b0f4cc3b038d760\""
        id            = "5807621"
        name          = "team-security"
        # (4 unchanged attributes hidden)
    }

  # module.github.github_team.teams["test-management"] has changed
  ~ resource "github_team" "teams" {
      ~ etag                      = "W/\"a7275d8a4b9f8a93cc378dda33fcd2c85d4fa714351e3cf836b49f2b5cc399de\"" -> "W/\"a0826a3ec198ce33efa8fa0c9e6e772a81eeb5eb7b308211db30faa2bd4f9e1d\""
        id                        = "6386786"
        name                      = "test-management"
        # (6 unchanged attributes hidden)
    }


Unless you have made equivalent changes to your configuration, or ignored the relevant attributes using ignore_changes, the following plan may include actions to undo or
respond to these changes.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.github.github_repository.repositories["product-puris-backend"] will be created
  + resource "github_repository" "repositories" {
      + allow_auto_merge            = false
      + allow_merge_commit          = true
      + allow_rebase_merge          = true
      + allow_squash_merge          = true
      + archived                    = false
      + auto_init                   = true
      + default_branch              = (known after apply)
      + delete_branch_on_merge      = true
      + etag                        = (known after apply)
      + full_name                   = (known after apply)
      + git_clone_url               = (known after apply)
      + has_downloads               = true
      + has_issues                  = false
      + has_projects                = false
      + has_wiki                    = false
      + html_url                    = (known after apply)
      + http_clone_url              = (known after apply)
      + id                          = (known after apply)
      + is_template                 = false
      + merge_commit_message        = "PR_TITLE"
      + merge_commit_title          = "MERGE_MESSAGE"
      + name                        = "product-puris-backend"
      + node_id                     = (known after apply)
      + private                     = (known after apply)
      + repo_id                     = (known after apply)
      + squash_merge_commit_message = "COMMIT_MESSAGES"
      + squash_merge_commit_title   = "COMMIT_OR_PR_TITLE"
      + ssh_clone_url               = (known after apply)
      + svn_url                     = (known after apply)
      + visibility                  = "public"
      + vulnerability_alerts        = true

      + pages {
          + custom_404 = (known after apply)
          + html_url   = (known after apply)
          + status     = (known after apply)
          + url        = (known after apply)

          + source {
              + branch = "gh-pages"
              + path   = "/"
            }
        }
    }

  # module.github.github_repository.repositories["product-puris-frontend"] will be created
  + resource "github_repository" "repositories" {
      + allow_auto_merge            = false
      + allow_merge_commit          = true
      + allow_rebase_merge          = true
      + allow_squash_merge          = true
      + archived                    = false
      + auto_init                   = true
      + default_branch              = (known after apply)
      + delete_branch_on_merge      = true
      + etag                        = (known after apply)
      + full_name                   = (known after apply)
      + git_clone_url               = (known after apply)
      + has_downloads               = true
      + has_issues                  = false
      + has_projects                = false
      + has_wiki                    = false
      + html_url                    = (known after apply)
      + http_clone_url              = (known after apply)
      + id                          = (known after apply)
      + is_template                 = false
      + merge_commit_message        = "PR_TITLE"
      + merge_commit_title          = "MERGE_MESSAGE"
      + name                        = "product-puris-frontend"
      + node_id                     = (known after apply)
      + private                     = (known after apply)
      + repo_id                     = (known after apply)
      + squash_merge_commit_message = "COMMIT_MESSAGES"
      + squash_merge_commit_title   = "COMMIT_OR_PR_TITLE"
      + ssh_clone_url               = (known after apply)
      + svn_url                     = (known after apply)
      + visibility                  = "public"
      + vulnerability_alerts        = true

      + pages {
          + custom_404 = (known after apply)
          + html_url   = (known after apply)
          + status     = (known after apply)
          + url        = (known after apply)

          + source {
              + branch = "gh-pages"
              + path   = "/"
            }
        }
    }

  # module.github.github_team.teams["product-puris"] will be created
  + resource "github_team" "teams" {
      + create_default_maintainer = false
      + description               = "Product Team puris"
      + etag                      = (known after apply)
      + id                        = (known after apply)
      + members_count             = (known after apply)
      + name                      = "product-puris"
      + node_id                   = (known after apply)
      + privacy                   = "closed"
      + slug                      = (known after apply)
    }

  # module.github.github_team_repository.team-repository-access["product-puris-backend-product-puris"] will be created
  + resource "github_team_repository" "team-repository-access" {
      + etag       = (known after apply)
      + id         = (known after apply)
      + permission = "maintain"
      + repository = "product-puris-backend"
      + team_id    = (known after apply)
    }

  # module.github.github_team_repository.team-repository-access["product-puris-frontend-product-puris"] will be created
  + resource "github_team_repository" "team-repository-access" {
      + etag       = (known after apply)
      + id         = (known after apply)
      + permission = "maintain"
      + repository = "product-puris-frontend"
      + team_id    = (known after apply)
    }

  # module.vault.vault_approle_auth_backend_role.product-team-approles["puris"] will be created
  + resource "vault_approle_auth_backend_role" "product-team-approles" {
      + backend            = "approle"
      + bind_secret_id     = true
      + id                 = (known after apply)
      + role_id            = (known after apply)
      + role_name          = "puris"
      + secret_id_num_uses = 0
      + secret_id_ttl      = 0
      + token_max_ttl      = 1800
      + token_num_uses     = 0
      + token_policies     = [
          + "puris-ro",
        ]
      + token_ttl          = 1200
      + token_type         = "default"
    }

  # module.vault.vault_approle_auth_backend_role_secret_id.product-teams-approle-ids["puris"] will be created
  + resource "vault_approle_auth_backend_role_secret_id" "product-teams-approle-ids" {
      + accessor          = (known after apply)
      + backend           = "approle"
      + id                = (known after apply)
      + role_name         = "puris"
      + secret_id         = (sensitive value)
      + wrapping_accessor = (known after apply)
      + wrapping_token    = (sensitive value)
    }

  # module.vault.vault_generic_secret.product-team-avp-secrets["puris"] will be created
  + resource "vault_generic_secret" "product-team-avp-secrets" {
      + data                = (sensitive value)
      + data_json           = (sensitive value)
      + delete_all_versions = false
      + disable_read        = false
      + id                  = (known after apply)
      + path                = "devsecops/avp-config/puris"
    }

  # module.vault.vault_github_team.github-product-teams["puris"] will be created
  + resource "vault_github_team" "github-product-teams" {
      + backend  = "github"
      + id       = (known after apply)
      + policies = [
          + "puris-rw",
        ]
      + team     = "product-puris"
    }

  # module.vault.vault_jwt_auth_backend_role.oidc_auth_roles["puris"] will be created
  + resource "vault_jwt_auth_backend_role" "oidc_auth_roles" {
      + allowed_redirect_uris        = [
          + "http://localhost:8250/oidc/callback",
          + "https://vault.demo.catena-x.net/ui/vault/auth/oidc/oidc/callback",
        ]
      + backend                      = "oidc"
      + bound_claims                 = {
          + "groups" = "catenax-ng:product-puris"
        }
      + bound_claims_type            = (known after apply)
      + clock_skew_leeway            = 0
      + disable_bound_claims_parsing = false
      + expiration_leeway            = 0
      + id                           = (known after apply)
      + not_before_leeway            = 0
      + oidc_scopes                  = [
          + "email",
          + "groups",
          + "openid",
        ]
      + role_name                    = "product-puris"
      + role_type                    = "oidc"
      + token_policies               = [
          + "puris-rw",
        ]
      + token_type                   = "default"
      + user_claim                   = "email"
      + verbose_oidc_logging         = false
    }

  # module.vault.vault_mount.product-team-secret-engines["puris"] will be created
  + resource "vault_mount" "product-team-secret-engines" {
      + accessor                     = (known after apply)
      + audit_non_hmac_request_keys  = (known after apply)
      + audit_non_hmac_response_keys = (known after apply)
      + default_lease_ttl_seconds    = (known after apply)
      + description                  = "Secret engine for team puris"
      + external_entropy_access      = false
      + id                           = (known after apply)
      + max_lease_ttl_seconds        = (known after apply)
      + options                      = {
          + "version" = "2"
        }
      + path                         = "puris"
      + seal_wrap                    = (known after apply)
      + type                         = "kv"
    }

  # module.vault.vault_policy.product-approle-read-only-policies["puris"] will be created
  + resource "vault_policy" "product-approle-read-only-policies" {
      + id     = (known after apply)
      + name   = "puris-ro"
      + policy = <<-EOT
            path "puris/*" {
              capabilities = [ "read" ]
            }
        EOT
    }

  # module.vault.vault_policy.product-team-policies["puris"] will be created
  + resource "vault_policy" "product-team-policies" {
      + id     = (known after apply)
      + name   = "puris-rw"
      + policy = <<-EOT
            path "puris/*" {
              capabilities = [ "create", "read", "update", "delete", "list" ]
            }
        EOT
    }

Plan: 13 to add, 0 to change, 0 to destroy.
```
