### PR TITLE
chore: update components to the latest patch level

### DIFF
--- a/apps/argocd/base/plugins/argo-vault-plugin.yaml
+++ b/apps/argocd/base/plugins/argo-vault-plugin.yaml
@@ -24,7 +24,7 @@ spec:
         # Note the lack of the `v` prefix unlike the git tag
         env:
           - name: AVP_VERSION
-            value: "1.13.0"
+            value: "1.13.1"
         args:
           - >-
             wget -O argocd-vault-plugin

--- a/apps/certmanager/Chart.yaml
+++ b/apps/certmanager/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.1.3
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.16.1"
+appVersion: "1.10.1"
 
 dependencies:
 - name: cert-manager

--- a/apps/certmanager/Chart.yaml
+++ b/apps/certmanager/Chart.yaml
@@ -15,16 +15,16 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.16.0"
+appVersion: "1.16.1"
 
 dependencies:
 - name: cert-manager
   alias: certmanager
-  version: 1.10.0
+  version: 1.10.1
   repository: https://charts.jetstack.io

--- a/apps/kube-prometheus-stack/Chart.yaml
+++ b/apps/kube-prometheus-stack/Chart.yaml
@@ -15,16 +15,16 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1"
+appVersion: "0.1.1"
 
 dependencies:
   - name: kube-prometheus-stack
     alias: kube-prometheus-stack
-    version: 35.5.1
+    version: 35.5.4
     repository: https://prometheus-community.github.io/helm-charts

--- a/apps/kube-prometheus-stack/Chart.yaml
+++ b/apps/kube-prometheus-stack/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.1.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.1"
+appVersion: "35.5.4"
 
 dependencies:
   - name: kube-prometheus-stack

--- a/environments/core/applicationsets/certmanager-applicationset.yaml
+++ b/environments/core/applicationsets/certmanager-applicationset.yaml
@@ -8,25 +8,25 @@ spec:
       elements:
       - cluster: core
         cluster-name: in-cluster
-        targetRevision: HEAD
+        targetRevision: certmanager-1.10.0
       - cluster: dev
         cluster-name: dev
-        targetRevision: HEAD
+        targetRevision: certmanager-1.10.0
       - cluster: hotel-budapest
         cluster-name: hotel-budapest
-        targetRevision: HEAD
+        targetRevision: certmanager-1.10.0
       - cluster: vault
         cluster-name: vault-cluster
-        targetRevision: HEAD
+        targetRevision: certmanager-1.10.0
       - cluster: devsecops-testing
         cluster-name: devsecops-testing
         targetRevision: HEAD
       - cluster: pre-prod
         cluster-name: pre-prod
-        targetRevision: HEAD
+        targetRevision: certmanager-1.10.0
       - cluster: beta
         cluster-name: beta
-        targetRevision: HEAD
+        targetRevision: certmanager-1.10.0
 
   template:
     metadata:

--- a/environments/core/applicationsets/kube-prometheus-stack-applicationset.yaml
+++ b/environments/core/applicationsets/kube-prometheus-stack-applicationset.yaml
@@ -8,22 +8,22 @@ spec:
       elements:
       - cluster: core
         cluster-name: in-cluster
-        targetRevision: HEAD
+        targetRevision: kubeprometheusstack-35.5.1
       - cluster: dev
         cluster-name: dev
-        targetRevision: HEAD
+        targetRevision: kubeprometheusstack-35.5.1
       - cluster: hotel-budapest
         cluster-name: hotel-budapest
-        targetRevision: HEAD
+        targetRevision: kubeprometheusstack-35.5.1
       - cluster: devsecops-testing
         cluster-name: devsecops-testing
         targetRevision: feat/A1ODT-657-add-loki-logging
       - cluster: pre-prod
         cluster-name: pre-prod
-        targetRevision: HEAD
+        targetRevision: kubeprometheusstack-35.5.1
       - cluster: beta
         cluster-name: beta
-        targetRevision: HEAD
+        targetRevision: kubeprometheusstack-35.5.1
 
   template:
     metadata:


### PR DESCRIPTION
- argo-vault-plugin 1.13.0 -> 1.13.1
- cert-manager 1.10.0 -> 1.10.1
- kube-prometheus-stack 35.5.1 -> 35.5.4