### PR TITLE
chore: introduce Git Tag for ingress-nginx

### DIFF
--- a/environments/core/applicationsets/ingress-applicationset.yaml
+++ b/environments/core/applicationsets/ingress-applicationset.yaml
@@ -8,25 +8,25 @@ spec:
       elements:
       - cluster: core
         cluster-name: in-cluster
-        targetRevision: ingress-nginx-v4.2.3
+        targetRevision: ingress-nginx-v4.2.3-c1
       - cluster: dev
         cluster-name: dev
-        targetRevision: ingress-nginx-v4.2.3
+        targetRevision: ingress-nginx-v4.2.3-c1
       - cluster: hotel-budapest
         cluster-name: hotel-budapest
-        targetRevision: ingress-nginx-v4.2.3
+        targetRevision: ingress-nginx-v4.2.3-c1
       - cluster: vault
         cluster-name: vault-cluster
-        targetRevision: ingress-nginx-v4.2.3
+        targetRevision: ingress-nginx-v4.2.3-c1
       - cluster: devsecops-testing
         cluster-name: devsecops-testing
         targetRevision: HEAD
       - cluster: pre-prod
         cluster-name: pre-prod
-        targetRevision: ingress-nginx-v4.2.3
+        targetRevision: ingress-nginx-v4.2.3-c1
       - cluster: beta
         cluster-name: beta
-        targetRevision: ingress-nginx-v4.2.3
+        targetRevision: ingress-nginx-v4.2.3-c1
 
   template:
     metadata:

--- a/environments/core/applicationsets/ingress-applicationset.yaml
+++ b/environments/core/applicationsets/ingress-applicationset.yaml
@@ -8,25 +8,25 @@ spec:
       elements:
       - cluster: core
         cluster-name: in-cluster
-        targetRevision: HEAD
+        targetRevision: ingress-nginx-v4.2.3
       - cluster: dev
         cluster-name: dev
-        targetRevision: HEAD
+        targetRevision: ingress-nginx-v4.2.3
       - cluster: hotel-budapest
         cluster-name: hotel-budapest
-        targetRevision: HEAD
+        targetRevision: ingress-nginx-v4.2.3
       - cluster: vault
         cluster-name: vault-cluster
-        targetRevision: HEAD
+        targetRevision: ingress-nginx-v4.2.3
       - cluster: devsecops-testing
         cluster-name: devsecops-testing
         targetRevision: HEAD
       - cluster: pre-prod
         cluster-name: pre-prod
-        targetRevision: HEAD
+        targetRevision: ingress-nginx-v4.2.3
       - cluster: beta
         cluster-name: beta
-        targetRevision: HEAD
+        targetRevision: ingress-nginx-v4.2.3
 
   template:
     metadata:

--- a/environments/core/applicationsets/ingress-applicationset.yaml
+++ b/environments/core/applicationsets/ingress-applicationset.yaml
@@ -20,7 +20,7 @@ spec:
         targetRevision: ingress-nginx-v4.2.3-c1
       - cluster: devsecops-testing
         cluster-name: devsecops-testing
-        targetRevision: HEAD
+        targetRevision: chore/dev_ingress_defaultBackend
       - cluster: pre-prod
         cluster-name: pre-prod
         targetRevision: ingress-nginx-v4.2.3-c1


### PR DESCRIPTION
Set ArgoCD Applicationset for ingress-nginx to Git Tag `ingress-nginx-v4.2.3` instead of `HEAD` to be able to test other versions on _devsecops-testing_ cluster.

Referenced tag already created and points to the #PR186 which represents the latest changes in ingress configuration:

```shell
$ git show ingress-nginx-v4.2.3
tag ingress-nginx-v4.2.3
Tagger: Carsten Lenz <carsten.lenz@mercedes-benz.com>
Date:   Mon Dec 19 12:25:58 2022 +0100

Helm Chart version 4.2.3
appVersion 1.3.0
Current config as of 19.12.2022

commit 2586c1dd89fb0a67cfa7abe6fa48d6dffc1a5b5f (tag: ingress-nginx-v4.2.3)
Author: sgrigar <108792047+sgrigar@users.noreply.github.com>
Date:   Mon Aug 29 14:16:07 2022 +0200

    fix: add annotation for health check probe for K8S version >= 1.24 (#186)
    
    Co-authored-by: GRIGARS <steffen.grigar@daimler.com>
[ ... ]
```
