### PR TITLE
build: upgrade devsecops-testing k8s version

### DIFF
--- a/terraform/02_devsecops-testing_cluster/terraform.tfvars
+++ b/terraform/02_devsecops-testing_cluster/terraform.tfvars
@@ -1,4 +1,4 @@
 environment_name="devsecops-testing"
 k8s_vm_size="Standard_D8s_v4"
-k8s_version = "1.24.3"
+k8s_version = "1.24.6"
 k8s_cluster_node_count = 4


### PR DESCRIPTION
New version is 1.24.6

Terraform plan output:
```
Terraform will perform the following actions:

  # module.aks.azurerm_kubernetes_cluster.aks_cluster will be updated in-place
  ~ resource "azurerm_kubernetes_cluster" "aks_cluster" {
        id                                  = "/subscriptions/899135fc-19c6-47cb-82f1-0230af7b99b5/resourcegroups/cx-devsecops-testing-rg/providers/Microsoft.ContainerService/managedClusters/cx-devsecops-testing-aks"
      ~ kubernetes_version                  = "1.24.3" -> "1.24.6"
        name                                = "cx-devsecops-testing-aks"
        tags                                = {}
        # (22 unchanged attributes hidden)

      ~ default_node_pool {
            name                         = "default"
          ~ orchestrator_version         = "1.24.3" -> "1.24.6"
            tags                         = {}
            # (19 unchanged attributes hidden)
        }

        # (3 unchanged blocks hidden)
    }

  # module.resource_group.azurerm_resource_group.default_resource_group will be updated in-place
  ~ resource "azurerm_resource_group" "default_resource_group" {
        id       = "/subscriptions/899135fc-19c6-47cb-82f1-0230af7b99b5/resourceGroups/cx-devsecops-testing-rg"
        name     = "cx-devsecops-testing-rg"
      ~ tags     = {
          - "environment" = "dev" -> null
        }
        # (1 unchanged attribute hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 2 to change, 0 to destroy.
```