### PR TITLE
chore: bump ArgoCD Version to 2.4.18

### DIFF
--- a/apps/argocd/base/kustomization.yaml
+++ b/apps/argocd/base/kustomization.yaml
@@ -4,7 +4,7 @@ namespace: argocd
 
 resources:
   - namespace.yaml
-  - https://raw.githubusercontent.com/argoproj/argo-cd/v2.4.16/manifests/ha/install.yaml
+  - https://raw.githubusercontent.com/argoproj/argo-cd/v2.4.18/manifests/ha/install.yaml
   - rbac-secret-access.yaml # grant avp access to secret with AVP configuration
 
 patchesStrategicMerge:


### PR DESCRIPTION
Update ArgoCD Version to 2.4.18. 