### PR TITLE
chore: new repository product-behaviour-twin-minio

### DIFF
--- a/terraform/100_team_onboarding/main.tf
+++ b/terraform/100_team_onboarding/main.tf
@@ -1825,6 +1825,23 @@ module "github" {
       codeowners_available : false
       codeowners : null
     },
+    "product-behaviour-twin-minio" : {
+      name : "product-behaviour-twin-minio"
+      team_name : ""
+      description : ""
+      visibility : "private"
+      homepage_url : ""
+      topics : []
+      pages : {
+        enabled : false
+        branch : ""
+      }
+      is_template : false
+      uses_template : false
+      template : null
+      codeowners_available : false
+      codeowners : null
+    }
   }
 
   github_repositories_teams = {
@@ -2267,6 +2284,11 @@ module "github" {
     "product-r-strategy-assistant-product-r-strategy-assistant" : {
       team_name : "product-r-strategy-assistant"
       repository : "product-r-strategy-assistant"
+      permission : "maintain"
+    },
+    "product-behaviour-twin-minio-product-behaviour-twin-minio" : {
+      team_name : "product-behaviour-twin-pilot"
+      repository : "product-behaviour-twin-minio"
       permission : "maintain"
     }
   }


### PR DESCRIPTION
Add new repo to catena-x ng.

terraform plan runs as expected, but hasn't been applied. Will be after merging to main:

```shell
Terraform will perform the following actions:

  # module.github.github_repository.repositories["product-behaviour-twin-minio"] will be created
  + resource "github_repository" "repositories" {
      + allow_auto_merge            = false
      + allow_merge_commit          = true
      + allow_rebase_merge          = true
      + allow_squash_merge          = true
      + archived                    = false
      + auto_init                   = true
      + default_branch              = (known after apply)
      + delete_branch_on_merge      = true
      + etag                        = (known after apply)
      + full_name                   = (known after apply)
      + git_clone_url               = (known after apply)
      + has_downloads               = true
      + has_issues                  = false
      + has_projects                = false
      + has_wiki                    = false
      + html_url                    = (known after apply)
      + http_clone_url              = (known after apply)
      + id                          = (known after apply)
      + is_template                 = false
      + merge_commit_message        = "PR_TITLE"
      + merge_commit_title          = "MERGE_MESSAGE"
      + name                        = "product-behaviour-twin-minio"
      + node_id                     = (known after apply)
      + private                     = (known after apply)
      + repo_id                     = (known after apply)
      + squash_merge_commit_message = "COMMIT_MESSAGES"
      + squash_merge_commit_title   = "COMMIT_OR_PR_TITLE"
      + ssh_clone_url               = (known after apply)
      + svn_url                     = (known after apply)
      + visibility                  = "private"
      + vulnerability_alerts        = true
    }

  # module.github.github_team_repository.team-repository-access["product-behaviour-twin-minio-product-behaviour-twin-minio"] will be created
  + resource "github_team_repository" "team-repository-access" {
      + etag       = (known after apply)
      + id         = (known after apply)
      + permission = "maintain"
      + repository = "product-behaviour-twin-minio"
      + team_id    = "6177751"
    }

Plan: 2 to add, 0 to change, 0 to destroy.
```