### PR TITLE
chore: add eclipse fork to terraform

### DIFF
--- a/terraform/100_team_onboarding/main.tf
+++ b/terraform/100_team_onboarding/main.tf
@@ -1841,6 +1841,23 @@ module "github" {
       template : null
       codeowners_available : false
       codeowners : null
+    },
+    "tx-bpdm" : {
+      name : "tx-bpdm"
+      team_name : ""
+      description : "Fork of eclipse-tractusx/bpdm repository"
+      visibility : "public"
+      homepage_url : ""
+      topics : []
+      pages : {
+        enabled : false
+        branch : ""
+      }
+      is_template : false
+      uses_template : false
+      template : null
+      codeowners_available : false
+      codeowners : null
     }
   }
 
@@ -2289,6 +2306,11 @@ module "github" {
     "product-behaviour-twin-minio-product-behaviour-twin-minio" : {
       team_name : "product-behaviour-twin-pilot"
       repository : "product-behaviour-twin-minio"
+      permission : "maintain"
+    },
+    "tx-bpdm-tx-bpdm" : {
+      team_name : "product-bpdm"
+      repository : "tx-bpdm"
       permission : "maintain"
     }
   }


### PR DESCRIPTION
New forked repo tx-bpdm.

Terraform plan as expected (after terraform import):

```shell
Terraform will perform the following actions:

  # module.github.github_repository.repositories["tx-bpdm"] will be updated in-place
  ~ resource "github_repository" "repositories" {
      ~ auto_init                   = false -> true
      ~ delete_branch_on_merge      = false -> true
      ~ has_projects                = true -> false
      ~ has_wiki                    = true -> false
        id                          = "tx-bpdm"
        name                        = "tx-bpdm"
      ~ vulnerability_alerts        = false -> true
        # (27 unchanged attributes hidden)
    }

  # module.github.github_team_repository.team-repository-access["tx-bpdm-tx-bpdm"] will be created
  + resource "github_team_repository" "team-repository-access" {
      + etag       = (known after apply)
      + id         = (known after apply)
      + permission = "maintain"
      + repository = "tx-bpdm"
      + team_id    = "5788667"
    }

Plan: 1 to add, 1 to change, 0 to destroy.
```