### PR TITLE
feat: aks control plane to use managed identity

### DIFF
--- a/terraform/modules/aks_cluster/main.tf
+++ b/terraform/modules/aks_cluster/main.tf
@@ -14,10 +14,14 @@ resource "azurerm_kubernetes_cluster" "aks_cluster" {
     min_count = var.min_count
   }
 
-  service_principal {
-    client_id     = var.aks_service_principal_client_id
-    client_secret = var.aks_service_principal_client_secret
+  identity {
+    type         = "SystemAssigned"
   }
+
+#  service_principal {
+#    client_id     = var.aks_service_principal_client_id
+#    client_secret = var.aks_service_principal_client_secret
+#  }
 
   dns_prefix         = var.aks_dns_prefix
   kubernetes_version = var.k8s_version

--- a/terraform/modules/aks_cluster/main.tf
+++ b/terraform/modules/aks_cluster/main.tf
@@ -18,11 +18,6 @@ resource "azurerm_kubernetes_cluster" "aks_cluster" {
     type         = "SystemAssigned"
   }
 
-#  service_principal {
-#    client_id     = var.aks_service_principal_client_id
-#    client_secret = var.aks_service_principal_client_secret
-#  }
-
   dns_prefix         = var.aks_dns_prefix
   kubernetes_version = var.k8s_version
 }


### PR DESCRIPTION
A migration scenario from service_principal to identity is supported. When upgrading service_principal to identity, your cluster's control plane and addon pods will switch to use managed identity, but the kubelets will keep using your configured service_principal until you upgrade your Node Pool.

To upgrade nodepool, run (example):
az aks nodepool upgrade --name default --resource-group cx-devsecops-testing-rg --cluster-name cx-devsecops-testing-aks --node-image-only