### PR TITLE
chore: reverted applicationset revision to HEAD

### DIFF
--- a/environments/core/applicationsets/kube-prometheus-stack-applicationset.yaml
+++ b/environments/core/applicationsets/kube-prometheus-stack-applicationset.yaml
@@ -17,7 +17,7 @@ spec:
         targetRevision: HEAD
       - cluster: devsecops-testing
         cluster-name: devsecops-testing
-        targetRevision: feat/A1ODT-657-add-loki-logging
+        targetRevision: HEAD
       - cluster: pre-prod
         cluster-name: pre-prod
         targetRevision: HEAD


### PR DESCRIPTION
no longer needed as HEAD contains all the changes of the branch in the meantime