### PR TITLE
feat: add cluster stack umbrella chart #A1ODT-1170

### DIFF
--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -1,0 +1,34 @@
+name: Release Helm Charts
+
+on:
+  push:
+    paths:
+      - 'charts/**'
+    branches:
+      - main
+jobs:
+  release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+
+    steps:
+      # fetch-depth: 0 is required to determine differences in chart(s)
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.4.1
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/charts/catena-cluster-stack/.helmignore
+++ b/charts/catena-cluster-stack/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/catena-cluster-stack/Chart.yaml
+++ b/charts/catena-cluster-stack/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+name: catena-cluster-stack
+description: A Helm chart installing the default stack components for k8s clusters running at the Catena-X consortium
+
+type: application
+
+version: 0.1.0
+
+appVersion: "0.1.0"
+
+dependencies:
+  - name: ingress-nginx
+    alias: ingress-nginx
+    version: 4.2.3
+    repository: https://kubernetes.github.io/ingress-nginx

--- a/charts/catena-cluster-stack/Chart.yaml
+++ b/charts/catena-cluster-stack/Chart.yaml
@@ -26,3 +26,6 @@ dependencies:
     alias: loki
     version: 3.10.0
     repository: https://grafana.github.io/helm-charts
+  - name: reflector
+    version: 6.1.47
+    repository: https://emberstack.github.io/helm-charts

--- a/charts/catena-cluster-stack/Chart.yaml
+++ b/charts/catena-cluster-stack/Chart.yaml
@@ -17,3 +17,8 @@ dependencies:
     alias: certmanager
     version: 1.10.0
     repository: https://charts.jetstack.io
+    condition: tls.enableTLSComponents
+  - name: kube-prometheus-stack
+    alias: kube-prometheus-stack
+    version: 35.5.1
+    repository: https://prometheus-community.github.io/helm-charts

--- a/charts/catena-cluster-stack/Chart.yaml
+++ b/charts/catena-cluster-stack/Chart.yaml
@@ -13,3 +13,7 @@ dependencies:
     alias: ingress-nginx
     version: 4.2.3
     repository: https://kubernetes.github.io/ingress-nginx
+  - name: cert-manager
+    alias: certmanager
+    version: 1.10.0
+    repository: https://charts.jetstack.io

--- a/charts/catena-cluster-stack/Chart.yaml
+++ b/charts/catena-cluster-stack/Chart.yaml
@@ -22,3 +22,7 @@ dependencies:
     alias: kube-prometheus-stack
     version: 35.5.1
     repository: https://prometheus-community.github.io/helm-charts
+  - name: loki
+    alias: loki
+    version: 3.10.0
+    repository: https://grafana.github.io/helm-charts

--- a/charts/catena-cluster-stack/README.md
+++ b/charts/catena-cluster-stack/README.md
@@ -86,3 +86,5 @@ The official [kube-prometheus-stack Chart](https://github.com/prometheus-communi
 is included. Check out the docs, how to set a custom admin password, or specify other login mechanisms.
 
 ### Loki
+
+### Reflector

--- a/charts/catena-cluster-stack/README.md
+++ b/charts/catena-cluster-stack/README.md
@@ -38,7 +38,13 @@ ingress-nginx:
         service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: "/healthz"
 ```
 
-### cert-manager
+### TLS
+
+This section describes, which resources are created to add TLS tooling and configuration.
+TLS resources are only added, if `tls.enableTLSComponents` is set to `true`. This is the default value.
+
+If `tls.enableTLSComponents` is set to `true`, [cert-manager](https://cert-manager.io/docs/) is added alongside a
+`ClusterIssuer` resource to issue certificates via LetsEncrypt](https://letsencrypt.org/).
 
 The alias used for cert-manager is `certmanager`. Check out available config option on the
 [official ArtifactHUB documentation](https://artifacthub.io/packages/helm/cert-manager/cert-manager#configuration).
@@ -71,3 +77,8 @@ tls:
         subscriptionID: {{ .Values.issuer.azure.subscriptionID }}
         tenantID: {{ .Values.issuer.azure.tenantID }}
 ```
+
+### kube-prometheus-stack
+
+The official [kube-prometheus-stack Chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
+is included. Check out the docs, how to set a custom admin password, or specify other login mechanisms.

--- a/charts/catena-cluster-stack/README.md
+++ b/charts/catena-cluster-stack/README.md
@@ -1,0 +1,36 @@
+# Catena-X cluster stack umbrella Chart
+
+This [Helm](https://helm.sh/) chart combines a set of tools, that is used on Catena-X consortium kubernetes
+environments. It forms a solid basis for operating and monitoring applications on the cluster and can also be used on
+non consortium environments.
+
+The stack focuses on operating and monitoring. It does not contain tooling for a specific deployment strategy, like
+GitOps controllers or similar.
+
+## The stack
+
+The stack installed by this Chart consists of the following tools:
+
+- [ingress-nginx](https://github.com/kubernetes/ingress-nginx) as ingress controller
+
+## Configuration
+
+The following sections contain specific configuration topics for each tool of the stack.
+
+### ingress-nginx
+
+The alias used for the ingress-nginx dependency is: `ingress-nginx`. Check out the configuration options for
+ingress-nginx in
+the [official docs](https://docs.nginx.com/nginx-ingress-controller/installation/installation-with-helm/#configuration).
+
+__Cloud provider specific annotations:__
+
+```yaml
+# Azure - There have been issues, where Azure AKS could not get health information from ingress-nginx and therefore
+# did not route any traffic to the cluster. This was solved by specifying the health check path manually
+ingress-nginx:
+  controller:
+    service:
+      annotations:
+        service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: "/healthz"
+```

--- a/charts/catena-cluster-stack/README.md
+++ b/charts/catena-cluster-stack/README.md
@@ -19,18 +19,55 @@ The following sections contain specific configuration topics for each tool of th
 
 ### ingress-nginx
 
-The alias used for the ingress-nginx dependency is: `ingress-nginx`. Check out the configuration options for
+The alias used for the ingress-nginx dependency is `ingress-nginx`. Check out the configuration options for
 ingress-nginx in
 the [official docs](https://docs.nginx.com/nginx-ingress-controller/installation/installation-with-helm/#configuration).
 
 __Cloud provider specific annotations:__
 
+There have been issues, where Azure AKS could not get health information from ingress-nginx and therefore did not route
+any traffic to the cluster. This was solved by specifying the health check path manually. Azure specific.
+
 ```yaml
-# Azure - There have been issues, where Azure AKS could not get health information from ingress-nginx and therefore
-# did not route any traffic to the cluster. This was solved by specifying the health check path manually
+# values.yaml
+...
 ingress-nginx:
   controller:
     service:
       annotations:
         service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: "/healthz"
+```
+
+### cert-manager
+
+The alias used for cert-manager is `certmanager`. Check out available config option on the
+[official ArtifactHUB documentation](https://artifacthub.io/packages/helm/cert-manager/cert-manager#configuration).
+
+__Set credentials to allow DNS zone configuration:__
+
+TLS certificates are generated via [LetsEncrypt](https://letsencrypt.org/). To answer LetsEncrypt challenges,
+cert-manager has to temporarily add routes to the DNS zone
+
+```yaml
+# values.yaml
+...
+tls:
+  dnsClientSecret: <your-dns-client-secret>
+```
+
+__DNS resolvers:__
+
+Azure DNS example:
+```yaml
+# values.yaml
+tls: 
+  solvers: 
+    - dns01:
+        azureDNS:
+        clientID: <azure-dns-zone-client-id>
+        clientSecretSecretRef: <
+        hostedZoneName: {{ .Values.issuer.azure.hostedZoneName }}
+        resourceGroupName: {{ .Values.issuer.azure.resourceGroupName }}
+        subscriptionID: {{ .Values.issuer.azure.subscriptionID }}
+        tenantID: {{ .Values.issuer.azure.tenantID }}
 ```

--- a/charts/catena-cluster-stack/README.md
+++ b/charts/catena-cluster-stack/README.md
@@ -71,14 +71,18 @@ tls:
     - dns01:
         azureDNS:
         clientID: <azure-dns-zone-client-id>
-        clientSecretSecretRef: <
-        hostedZoneName: {{ .Values.issuer.azure.hostedZoneName }}
-        resourceGroupName: {{ .Values.issuer.azure.resourceGroupName }}
-        subscriptionID: {{ .Values.issuer.azure.subscriptionID }}
-        tenantID: {{ .Values.issuer.azure.tenantID }}
+        clientSecretSecretRef: 
+          name: <dns-zone-client-secret-name>
+          key: <dns-zone-client-secret-key>
+        hostedZoneName: <azure-hosted-zone-name>
+        resourceGroupName: <azure-resource-group-name>
+        subscriptionID: <azure-subscription-id>
+        tenantID: <azure-tenant-id>
 ```
 
 ### kube-prometheus-stack
 
 The official [kube-prometheus-stack Chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
 is included. Check out the docs, how to set a custom admin password, or specify other login mechanisms.
+
+### Loki

--- a/charts/catena-cluster-stack/templates/dns-config-secret.yaml
+++ b/charts/catena-cluster-stack/templates/dns-config-secret.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.tls.enableTLSComponents -}}
+{{- if .Values.tls.dnsClientSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.tls.dnsClientSecretName }}
+  namespace: {{ .Release.Namespace}}
+type: Opaque
+stringData:
+  {{ .Values.tls.dnsClientSecretKey }}: {{ .Values.tls.dnsClientSecretValue }}
+{{- end -}}
+{{- end -}}

--- a/charts/catena-cluster-stack/templates/tls-certificate.yaml
+++ b/charts/catena-cluster-stack/templates/tls-certificate.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.tls.enableTLSComponents -}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: le-crt
+  namespace: default
+spec:
+  secretName: tls-secret
+  issuerRef:
+    kind: ClusterIssuer
+    name: letsencrypt-prod
+  commonName: "*.{{ .Values.tls.dnsZoneName }}"
+  dnsNames:
+    {{- range .Values.tls.dnsZoneNames -}}
+    - "*.{{ . }}"
+    {{- end}}
+  duration: 2160h0m0s # 90d
+  renewBefore: 360h0m0s # 15d
+  secretTemplate:
+    annotations:
+      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true" # Auto create reflection for matching namespaces
+{{- end -}}

--- a/charts/catena-cluster-stack/templates/tls-cluster-Issuer.yaml
+++ b/charts/catena-cluster-stack/templates/tls-cluster-Issuer.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.tls.enableTLSComponents -}}
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: "https://acme-v02.api.letsencrypt.org/directory"
+    #server: "https://acme-staging-v02.api.letsencrypt.org/directory"
+    email: {{ .Values.tls.issuerEmail }}
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    {{- if .Values.tls.solvers }}
+    solvers:
+      {{- range .Values.tls.solvers -}}
+      {{- toYaml . | nindent 6 }}
+      {{ end }}
+    {{- end -}}
+{{- end -}}

--- a/charts/catena-cluster-stack/values.yaml
+++ b/charts/catena-cluster-stack/values.yaml
@@ -44,3 +44,10 @@ tls:
   #        resourceGroupName: "<dns-zone-resource-group-name"
   #        subscriptionID: "<dns-zone-subscription-id>"
   #        tenantID: "<dns-zone-azure-subscription-id>"
+kube-prometheus-stack:
+  prometheusOperator:
+    # https://github.com/prometheus-community/helm-charts/issues/479#issuecomment-752709725
+    tls:
+      enabled: false
+    admissionWebhooks:
+      enabled: false

--- a/charts/catena-cluster-stack/values.yaml
+++ b/charts/catena-cluster-stack/values.yaml
@@ -8,3 +8,39 @@ ingress-nginx:
       enable-underscores-in-headers: "true"
   defaultBackend:
     enabled: true
+
+certmanager:
+  installCRDs: true
+
+tls:
+  # enableTLSComponents specifies, if a ClusterIssuer configured for LetsEncrypt will be included
+  enableTLSComponents: true
+
+  # dnsClientSecretName is the name of the secret storing DNS zone configuration
+  dnsClientSecretName: "dns-config"
+  # dnsClientKey is the key name in the k8s secret containing client secret values for potential DNS zone access
+  dnsClientSecretKey: "dnsClientKey"
+  # dnsClientSecret is the client secret used to authenticate for DNS configuration
+  dnsClientSecretValue: ""
+
+  # issuerEmail is the LetsEncrypt account email
+  issuerEmail: ""
+
+  # dnsZoneName is the name of the DNS zone. i.e. demo.catena-x.net
+  dnsZoneNames: {}
+  # - *.int.demo.catena-x.net
+  # - *.demo.catena-x.net
+
+  # solvers contains DNS zone provider specific configuration. Only included, if
+  solvers: []
+  # Azure example:
+  #  - dno01:
+  #      azuredns:
+  #        clientID: "<azrue-client-id>"
+  #        clientSecretSecretRef:
+  #          name: "dns-config" # -> value of dnsClientSecretName
+  #          key: "dnsClientKey" # -> value of dnsClientSecretKey
+  #        hostedZoneName: "<dns-zone-name>"
+  #        resourceGroupName: "<dns-zone-resource-group-name"
+  #        subscriptionID: "<dns-zone-subscription-id>"
+  #        tenantID: "<dns-zone-azure-subscription-id>"

--- a/charts/catena-cluster-stack/values.yaml
+++ b/charts/catena-cluster-stack/values.yaml
@@ -44,6 +44,7 @@ tls:
   #        resourceGroupName: "<dns-zone-resource-group-name"
   #        subscriptionID: "<dns-zone-subscription-id>"
   #        tenantID: "<dns-zone-azure-subscription-id>"
+
 kube-prometheus-stack:
   prometheusOperator:
     # https://github.com/prometheus-community/helm-charts/issues/479#issuecomment-752709725
@@ -51,3 +52,10 @@ kube-prometheus-stack:
       enabled: false
     admissionWebhooks:
       enabled: false
+
+loki:
+  loki:
+    commonConfig:
+      replication_factor: 1
+    storage:
+      type: 'filesystem'

--- a/charts/catena-cluster-stack/values.yaml
+++ b/charts/catena-cluster-stack/values.yaml
@@ -1,0 +1,10 @@
+ingress-nginx:
+  controller:
+    ingressClassResource:
+      default: true
+    watchIngressWithoutClass: true
+    config:
+      # @url: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#enable-underscores-in-headers
+      enable-underscores-in-headers: "true"
+  defaultBackend:
+    enabled: true


### PR DESCRIPTION
This PR introduces an umbrella chart containing our kubernetes stack components.
Cluster/environment specific configuration is intentionally left out, since this chart should be usable on any cluster.

Kyverno is currently missing in the umbrella chart, since we have to figure out, how we want to integrate the additional kustomization, that we do for kyverno on our environments