### PR TITLE
chore: bump ArgoCD to latest 2.4 patchlevel

### DIFF
--- a/apps/argocd/base/kustomization.yaml
+++ b/apps/argocd/base/kustomization.yaml
@@ -4,7 +4,7 @@ namespace: argocd
 
 resources:
   - namespace.yaml
-  - https://raw.githubusercontent.com/argoproj/argo-cd/v2.4.18/manifests/ha/install.yaml
+  - https://raw.githubusercontent.com/argoproj/argo-cd/v2.4.21/manifests/ha/install.yaml
   - rbac-secret-access.yaml # grant avp access to secret with AVP configuration
 
 patchesStrategicMerge:

--- a/apps/argocd/base/plugins/argo-vault-plugin.yaml
+++ b/apps/argocd/base/plugins/argo-vault-plugin.yaml
@@ -24,7 +24,7 @@ spec:
         # Note the lack of the `v` prefix unlike the git tag
         env:
           - name: AVP_VERSION
-            value: "1.13.0"
+            value: "1.13.1"
         args:
           - >-
             wget -O argocd-vault-plugin


### PR DESCRIPTION
Bump ArgoCD to v2.4.21 to apply latest security (2.4.20) and bugfix (2.4.21) patch releases.