### PR TITLE
chore: avp setup core cluster

### DIFF
--- a/apps/argocd/overlays/core/configmap/avp-argocd-cm.yaml
+++ b/apps/argocd/overlays/core/configmap/avp-argocd-cm.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+data:
+  configManagementPlugins: |-
+    - name: argocd-vault-plugin
+      generate:
+        command: ["sh", "-c"]
+        args: ["argocd-vault-plugin generate -s vault-secret ./"]
+    - name: argocd-vault-plugin-helm
+      init:
+        command: [sh, -c]
+        args: ["helm dependency update -n $ARGOCD_APP_NAMESPACE"]
+      generate:
+        command: ["sh", "-c"]
+        args: ["helm template $ARGOCD_APP_NAME -n $ARGOCD_APP_NAMESPACE . | argocd-vault-plugin generate - -s vault-secret"]
+    - name: argocd-vault-plugin-helm-args
+      init:
+        command: [sh, -c]
+        args: ["helm dependency update -n $ARGOCD_APP_NAMESPACE"]
+      generate:
+        command: ["sh", "-c"]
+        args: ["helm template $ARGOCD_APP_NAME -n $ARGOCD_APP_NAMESPACE ${ARGOCD_ENV_helm_args} . | argocd-vault-plugin generate - -s vault-secret"]
+    - name: argocd-vault-plugin-kustomize
+      generate:
+        command: ["sh", "-c"]
+        args: ["kustomize build . | argocd-vault-plugin generate - -s vault-secret"]
+    - name: argocd-vault-plugin-kustomize-helm-args
+      init:
+          command: [sh, -c]
+          args: ["helm dependency update -n $ARGOCD_APP_NAMESPACE"]
+      generate:
+        command: ["sh", "-c"]
+        args: ["helm template $ARGOCD_APP_NAME -n $ARGOCD_APP_NAMESPACE ${ARGOCD_ENV_helm_args} . > manifest.yaml && kustomize build | argocd-vault-plugin generate - -s vault-secret"]

--- a/apps/argocd/overlays/core/kustomization.yaml
+++ b/apps/argocd/overlays/core/kustomization.yaml
@@ -16,4 +16,4 @@ resources:
 
 patchesStrategicMerge:
   - configmap/argo-cm.yaml
-
+  - configmap/avp-argocd-cm.yaml

--- a/environments/core/applicationsets/argo-applicationset.yaml
+++ b/environments/core/applicationsets/argo-applicationset.yaml
@@ -9,15 +9,15 @@ spec:
       - cluster: core
         cluster-name: in-cluster
         overlay: overlays/core
-        targetRevision: ArgoCD-v2.4.21-c1_AVP-v1.13.1
+        targetRevision: ArgoCD-v2.4.21-c2_AVP-v1.13.1
       - cluster: hotel-budapest
         cluster-name: hotel-budapest
         overlay: overlays/hotel-budapest
-        targetRevision: ArgoCD-v2.4.21-c1_AVP-v1.13.1
+        targetRevision: ArgoCD-v2.4.21-c2_AVP-v1.13.1
       - cluster: dev
         cluster-name: dev
         overlay: overlays/dev
-        targetRevision: ArgoCD-v2.4.21-c1_AVP-v1.13.1
+        targetRevision: ArgoCD-v2.4.21-c2_AVP-v1.13.1
       - cluster: devsecops-testing
         cluster-name: devsecops-testing
         overlay: overlays/devsecops-testing
@@ -25,11 +25,11 @@ spec:
       - cluster: pre-prod
         cluster-name: pre-prod
         overlay: overlays/pre-prod
-        targetRevision: ArgoCD-v2.4.21-c1_AVP-v1.13.1
+        targetRevision: ArgoCD-v2.4.21-c2_AVP-v1.13.1
       - cluster: beta
         cluster-name: beta
         overlay: overlays/beta
-        targetRevision: ArgoCD-v2.4.21-c1_AVP-v1.13.1
+        targetRevision: ArgoCD-v2.4.21-c2_AVP-v1.13.1
 
   template:
     metadata:


### PR DESCRIPTION
Let core AVP config use vault-secret in argocd namespace (ENV cluster use `argocd-vault-plugin generate - -s $ARGOCD_APP_NAMESPACE:vault-secret`, core `argocd-vault-plugin generate - -s vault-secret`)