### PR TITLE
chore: switch targetRevision for devsecops-testing cluster

### DIFF
--- a/environments/core/applicationsets/argo-applicationset.yaml
+++ b/environments/core/applicationsets/argo-applicationset.yaml
@@ -21,7 +21,8 @@ spec:
       - cluster: devsecops-testing
         cluster-name: devsecops-testing
         overlay: overlays/devsecops-testing
-        targetRevision: HEAD # intentional for testing purposes, don't change without good reason
+        targetRevision: feat/argocd_2.5 # temp branch for testing upgrade and AVP implementation
+#        targetRevision: HEAD # intentional for testing purposes, don't change without good reason
       - cluster: pre-prod
         cluster-name: pre-prod
         overlay: overlays/pre-prod

--- a/environments/core/applicationsets/argo-applicationset.yaml
+++ b/environments/core/applicationsets/argo-applicationset.yaml
@@ -9,15 +9,15 @@ spec:
       - cluster: core
         cluster-name: in-cluster
         overlay: overlays/core
-        targetRevision: ArgoCD-v2.4.22-c3_AVP-v1.13.1
+        targetRevision: ArgoCD-v2.4.22-c4_AVP-v1.13.1
       - cluster: hotel-budapest
         cluster-name: hotel-budapest
         overlay: overlays/hotel-budapest
-        targetRevision: ArgoCD-v2.4.22-c3_AVP-v1.13.1
+        targetRevision: ArgoCD-v2.4.22-c4_AVP-v1.13.1
       - cluster: dev
         cluster-name: dev
         overlay: overlays/dev
-        targetRevision: ArgoCD-v2.4.22-c3_AVP-v1.13.1
+        targetRevision: ArgoCD-v2.4.22-c4_AVP-v1.13.1
       - cluster: devsecops-testing
         cluster-name: devsecops-testing
         overlay: overlays/devsecops-testing
@@ -26,11 +26,11 @@ spec:
       - cluster: pre-prod
         cluster-name: pre-prod
         overlay: overlays/pre-prod
-        targetRevision: ArgoCD-v2.4.22-c3_AVP-v1.13.1
+        targetRevision: ArgoCD-v2.4.22-c4_AVP-v1.13.1
       - cluster: beta
         cluster-name: beta
         overlay: overlays/beta
-        targetRevision: ArgoCD-v2.4.22-c3_AVP-v1.13.1
+        targetRevision: ArgoCD-v2.4.22-c4_AVP-v1.13.1
 
   template:
     metadata:


### PR DESCRIPTION
To test ArgoCD 2.5 upgrade and new ArgoCD Vault Plugin approach (sidecar container instead of configMap setup), our devsecops-testing cluster will point to a feature branch instead of HEAD. Feature branch has been created from main and pushed.

After successful testing `targetRevision` for devsecops-testing cluster will be set back to HEAD again.

ArgoCD GH tag has been bumped (c3 → c4) to get changes applied.