### PR TITLE
Feat/enable argo notification

### DIFF
--- a/apps/argocd/base/argocd-notifications-secrets.yaml
+++ b/apps/argocd/base/argocd-notifications-secrets.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argocd-notifications-secret
+type: Opaque
+stringData:
+  irs-teams-channel-url: <path:devsecops/data/apps/argocd/argocd-notifications-secret#irs-teams-channel-url>
+  demo-teams-channel-url: <path:devsecops/data/apps/argocd/argocd-notifications-secret#demo-teams-channel-url>

--- a/apps/argocd/base/kustomization.yaml
+++ b/apps/argocd/base/kustomization.yaml
@@ -13,3 +13,4 @@ patchesStrategicMerge:
   - avp-argocd-cm.yaml
   - enable-webterminal.yaml
   - argo-notification-cm.yaml
+  - argocd-notifications-secrets.yaml

--- a/apps/argocd/overlays/devsecops-testing/configmap/argo-notification-channels.yaml
+++ b/apps/argocd/overlays/devsecops-testing/configmap/argo-notification-channels.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-notifications-cm
+data:
+  service.teams.irs: |
+    recipientUrls:
+      irs-dev-teams: $irs-teams-channel-url
+      demo-teams-channel: $demo-teams-channel-url

--- a/apps/argocd/overlays/devsecops-testing/kustomization.yaml
+++ b/apps/argocd/overlays/devsecops-testing/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
 
 patchesStrategicMerge:
   - configmap/argo-cm.yaml
+  - configmap/argo-notification-channels.yaml


### PR DESCRIPTION
- generally add notification secrets
- enabled teams urls to devsecops-testing cluster 
- also added private demo channel for testing purposes

already updated our vault secret to 2 entries 

my idea was general enablement for notification, because updating argo internal ressoucres from repo product-onboarding 
seems a bit wrong there.

For this approach we need to add may product specifica in our argo base repo but with this, we have may multible channels only based on the subspribed apps we can declare afterwards

Testing for demo-channel in devsecops cluster
