### PR TITLE
chore: update ArgoCD 2.4.24

### DIFF
--- a/apps/argocd/base/kustomization.yaml
+++ b/apps/argocd/base/kustomization.yaml
@@ -4,7 +4,7 @@ namespace: argocd
 
 resources:
   - namespace.yaml
-  - https://raw.githubusercontent.com/argoproj/argo-cd/v2.4.22/manifests/ha/install.yaml
+  - https://raw.githubusercontent.com/argoproj/argo-cd/v2.4.24/manifests/ha/install.yaml
   - avp-rbac-secret-access.yaml # grant avp access to secret with AVP configuration
 
 patchesStrategicMerge:

--- a/environments/core/applicationsets/argo-applicationset.yaml
+++ b/environments/core/applicationsets/argo-applicationset.yaml
@@ -9,15 +9,15 @@ spec:
       - cluster: core
         cluster-name: in-cluster
         overlay: overlays/core
-        targetRevision: ArgoCD-v2.4.22-c8_AVP-v1.13.1
+        targetRevision: ArgoCD-v2.4.24-c0_AVP-v1.13.1
       - cluster: hotel-budapest
         cluster-name: hotel-budapest
         overlay: overlays/hotel-budapest
-        targetRevision: ArgoCD-v2.4.22-c8_AVP-v1.13.1
+        targetRevision: ArgoCD-v2.4.24-c0_AVP-v1.13.1
       - cluster: dev
         cluster-name: dev
         overlay: overlays/dev
-        targetRevision: ArgoCD-v2.4.22-c8_AVP-v1.13.1
+        targetRevision: ArgoCD-v2.4.24-c0_AVP-v1.13.1
       - cluster: devsecops-testing
         cluster-name: devsecops-testing
         overlay: overlays/devsecops-testing
@@ -26,11 +26,11 @@ spec:
       - cluster: pre-prod
         cluster-name: pre-prod
         overlay: overlays/pre-prod
-        targetRevision: ArgoCD-v2.4.22-c8_AVP-v1.13.1
+        targetRevision: ArgoCD-v2.4.24-c0_AVP-v1.13.1
       - cluster: beta
         cluster-name: beta
         overlay: overlays/beta
-        targetRevision: ArgoCD-v2.4.22-c8_AVP-v1.13.1
+        targetRevision: ArgoCD-v2.4.24-c0_AVP-v1.13.1
 
   template:
     metadata:


### PR DESCRIPTION
Bump ArgoCD version to `2.4.24` and GH tag to `ArgoCD-v2.4.22-c9_AVP-v1.13.1`