### PR TITLE
fix: sidecar image for avp helm kustomize

### DIFF
--- a/apps/argocd/base/vault-plugin/argo-repo-server-sidecars.yaml
+++ b/apps/argocd/base/vault-plugin/argo-repo-server-sidecars.yaml
@@ -120,7 +120,7 @@ spec:
         # argocd-vault-plugin with Kustomize and Helm
         - name: avp-helm-kustomize
           command: [ /var/run/argocd/argocd-cmp-server ]
-          image: quay.io/argoproj/
+          image: quay.io/argoproj/argocd:v2.6.6
           securityContext:
             runAsNonRoot: true
             runAsUser: 999

--- a/apps/argocd/base/vault-plugin/argo-repo-server-sidecars.yaml
+++ b/apps/argocd/base/vault-plugin/argo-repo-server-sidecars.yaml
@@ -45,7 +45,7 @@ spec:
         # argocd-vault-plugin with Helm values
         - name: avp-helm-values
           command: [ /var/run/argocd/argocd-cmp-server ]
-          image: quay.io/argoproj/argocd:v2.5.14
+          image: quay.io/argoproj/argocd:v2.6.6
           securityContext:
             runAsNonRoot: true
             runAsUser: 999
@@ -70,7 +70,7 @@ spec:
         # argocd-vault-plugin with Helm args
         - name: avp-helm-args
           command: [ /var/run/argocd/argocd-cmp-server ]
-          image: quay.io/argoproj/argocd:v2.5.14
+          image: quay.io/argoproj/argocd:v2.6.6
           securityContext:
             runAsNonRoot: true
             runAsUser: 999
@@ -95,7 +95,7 @@ spec:
         # argocd-vault-plugin with Kustomize
         - name: avp-kustomize
           command: [/var/run/argocd/argocd-cmp-server]
-          image: quay.io/argoproj/argocd:v2.5.14
+          image: quay.io/argoproj/argocd:v2.6.6
           securityContext:
             runAsNonRoot: true
             runAsUser: 999
@@ -145,7 +145,7 @@ spec:
         # argocd-vault-plugin with plain YAML
         - name: avp
           command: [/var/run/argocd/argocd-cmp-server]
-          image: quay.io/argoproj/argocd:v2.5.14
+          image: quay.io/argoproj/argocd:v2.6.6
           securityContext:
             runAsNonRoot: true
             runAsUser: 999


### PR DESCRIPTION
This is a fix pullrequest:
- add missing image to helm-kustomize sidecar
- align sidecar images to argocd image used in argocd-repo-server