### PR TITLE
chore: keep sidecar images in sync with ArgoCD version using kustomize

### DIFF
--- a/apps/argocd/base/kustomization.yaml
+++ b/apps/argocd/base/kustomization.yaml
@@ -2,9 +2,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: argocd
 
+# Keep newTag (images) and the version number of ArgoCD (resources) in sync. This will keep ArgoCD Repo Server
+# sidecar container images aligned to ArgoCD.
+# https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/images/
+images:
+  - name: quay.io/argoproj/argocd
+    newTag: v2.6.6
+
 resources:
   - namespace.yaml
-  - https://raw.githubusercontent.com/argoproj/argo-cd/v2.6.6/manifests/ha/install.yaml
+  - https://raw.githubusercontent.com/argoproj/argo-cd/v2.6.6/manifests/ha/install.yaml # ensure to keep images.newTag in sync
   - vault-plugin/vault-plugin-cm.yaml # AVP sidecar configuration
   - avp-rbac-secret-access.yaml # grant avp access to secret with AVP configuration
 


### PR DESCRIPTION
Manage ArgoCD version and argocd-repo-server sidecar container images using kustomize functionality. Only limitation: keep newTag and ArgoCD Version in sync.

This will simplify maintenance of ArgoCD and the sidecar container images.