### PR TITLE
chore: add our MS Teams channel to argo default base in cm + bump applicationset config version

### DIFF
--- a/apps/argocd/base/argo-notification-cm.yaml
+++ b/apps/argocd/base/argo-notification-cm.yaml
@@ -3,6 +3,11 @@ kind: ConfigMap
 metadata:
   name: argocd-notifications-cm
 data:
+  ## our default MS Teams Argo Cd notification channel
+  service.teams.system_team: |
+    recipientUrls:
+      argocdadmins-teams-channel: $argocd-teams-channel-url
+  ## all default templates for notification
   template.app-created: |
     email:
       subject: Application {{.app.metadata.name}} has been created.

--- a/apps/argocd/overlays/devsecops-testing/configmap/argo-notification-channels.yaml
+++ b/apps/argocd/overlays/devsecops-testing/configmap/argo-notification-channels.yaml
@@ -3,9 +3,6 @@ kind: ConfigMap
 metadata:
   name: argocd-notifications-cm
 data:
-  service.teams.system_team: |
-    recipientUrls:
-      argocdadmins-teams-channel: $argocd-teams-channel-url
   service.teams.irs: |
     recipientUrls:
       irs-dev-teams: $irs-teams-channel-url

--- a/environments/core/applicationsets/argo-applicationset.yaml
+++ b/environments/core/applicationsets/argo-applicationset.yaml
@@ -9,15 +9,15 @@ spec:
       - cluster: core
         cluster-name: in-cluster
         overlay: overlays/core
-        targetRevision: ArgoCD-v2.4.24-c1_AVP-v1.13.1
+        targetRevision: ArgoCD-v2.6.6-c1_AVP-v1.13.1
       - cluster: hotel-budapest
         cluster-name: hotel-budapest
         overlay: overlays/hotel-budapest
-        targetRevision: ArgoCD-v2.4.24-c1_AVP-v1.13.1
+        targetRevision: ArgoCD-v2.6.6-c1_AVP-v1.13.1
       - cluster: dev
         cluster-name: dev
         overlay: overlays/dev
-        targetRevision: ArgoCD-v2.4.24-c1_AVP-v1.13.1
+        targetRevision: ArgoCD-v2.6.6-c1_AVP-v1.13.1
       - cluster: devsecops-testing
         cluster-name: devsecops-testing
         overlay: overlays/devsecops-testing
@@ -25,11 +25,11 @@ spec:
       - cluster: pre-prod
         cluster-name: pre-prod
         overlay: overlays/pre-prod
-        targetRevision: ArgoCD-v2.4.24-c1_AVP-v1.13.1
+        targetRevision: ArgoCD-v2.6.6-c1_AVP-v1.13.1
       - cluster: beta
         cluster-name: beta
         overlay: overlays/beta
-        targetRevision: ArgoCD-v2.4.24-c1_AVP-v1.13.1
+        targetRevision: ArgoCD-v2.6.6-c1_AVP-v1.13.1
 
   template:
     metadata:

--- a/environments/core/applicationsets/argo-applicationset.yaml
+++ b/environments/core/applicationsets/argo-applicationset.yaml
@@ -9,15 +9,15 @@ spec:
       - cluster: core
         cluster-name: in-cluster
         overlay: overlays/core
-        targetRevision: ArgoCD-v2.4.24-c0_AVP-v1.13.1
+        targetRevision: ArgoCD-v2.4.24-c1_AVP-v1.13.1
       - cluster: hotel-budapest
         cluster-name: hotel-budapest
         overlay: overlays/hotel-budapest
-        targetRevision: ArgoCD-v2.4.24-c0_AVP-v1.13.1
+        targetRevision: ArgoCD-v2.4.24-c1_AVP-v1.13.1
       - cluster: dev
         cluster-name: dev
         overlay: overlays/dev
-        targetRevision: ArgoCD-v2.4.24-c0_AVP-v1.13.1
+        targetRevision: ArgoCD-v2.4.24-c1_AVP-v1.13.1
       - cluster: devsecops-testing
         cluster-name: devsecops-testing
         overlay: overlays/devsecops-testing
@@ -25,11 +25,11 @@ spec:
       - cluster: pre-prod
         cluster-name: pre-prod
         overlay: overlays/pre-prod
-        targetRevision: ArgoCD-v2.4.24-c0_AVP-v1.13.1
+        targetRevision: ArgoCD-v2.4.24-c1_AVP-v1.13.1
       - cluster: beta
         cluster-name: beta
         overlay: overlays/beta
-        targetRevision: ArgoCD-v2.4.24-c0_AVP-v1.13.1
+        targetRevision: ArgoCD-v2.4.24-c1_AVP-v1.13.1
 
   template:
     metadata:


### PR DESCRIPTION
- moved default MS Teams Channel to Argo Cd base that every cluster has the possibility 
- bumped config version for Argo Cd Set-Up
