### PR TITLE
chore: bump ingress-nginx helm chart to version 4.5.2

### DIFF
--- a/apps/ingress-nginx/Chart.yaml
+++ b/apps/ingress-nginx/Chart.yaml
@@ -26,5 +26,5 @@ appVersion: "1.16.0"
 dependencies:
 - name: ingress-nginx
   alias: ingress-nginx
-  version: 4.2.3
+  version: 4.5.2
   repository: https://kubernetes.github.io/ingress-nginx


### PR DESCRIPTION
Bump to latest version. Checked Changelogs 4.3.2 → 4.5.2. I do not expect problems.

After merging to main branch, testing new version first on our devsecops-testing cluster. The ingress-nginx Argo App for each cluster has disabled autosync, so there is no damage expeted.