### PR TITLE
chore: update ArgoCD (2.6.7) and AVP  (1.14.0)

### DIFF
--- a/apps/argocd/base/kustomization.yaml
+++ b/apps/argocd/base/kustomization.yaml
@@ -7,11 +7,11 @@ namespace: argocd
 # https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/images/
 images:
   - name: quay.io/argoproj/argocd
-    newTag: v2.6.6
+    newTag: v2.6.7
 
 resources:
   - namespace.yaml
-  - https://raw.githubusercontent.com/argoproj/argo-cd/v2.6.6/manifests/ha/install.yaml # ensure to keep images.newTag in sync
+  - https://raw.githubusercontent.com/argoproj/argo-cd/v2.6.7/manifests/ha/install.yaml # ensure to keep images.newTag in sync
   - vault-plugin/vault-plugin-cm.yaml # AVP sidecar configuration
   - avp-rbac-secret-access.yaml # grant avp access to secret with AVP configuration
 

--- a/apps/argocd/base/vault-plugin/argo-repo-server-sidecars.yaml
+++ b/apps/argocd/base/vault-plugin/argo-repo-server-sidecars.yaml
@@ -30,7 +30,7 @@ spec:
           image: registry.access.redhat.com/ubi8
           env:
             - name: AVP_VERSION
-              value: 1.13.1
+              value: 1.14.0
           command: [sh, -c]
           args:
             - >-

--- a/environments/core/applicationsets/argo-applicationset.yaml
+++ b/environments/core/applicationsets/argo-applicationset.yaml
@@ -9,15 +9,15 @@ spec:
       - cluster: core
         cluster-name: in-cluster
         overlay: overlays/core
-        targetRevision: ArgoCD-v2.4.24-c0_AVP-v1.13.1
+        targetRevision: ArgoCD-v2.6.7-c0_AVP-v1.14.0
       - cluster: hotel-budapest
         cluster-name: hotel-budapest
         overlay: overlays/hotel-budapest
-        targetRevision: ArgoCD-v2.4.24-c0_AVP-v1.13.1
+        targetRevision: ArgoCD-v2.6.7-c0_AVP-v1.14.0
       - cluster: dev
         cluster-name: dev
         overlay: overlays/dev
-        targetRevision: ArgoCD-v2.4.24-c0_AVP-v1.13.1
+        targetRevision: ArgoCD-v2.6.7-c0_AVP-v1.14.0
       - cluster: devsecops-testing
         cluster-name: devsecops-testing
         overlay: overlays/devsecops-testing
@@ -25,11 +25,11 @@ spec:
       - cluster: pre-prod
         cluster-name: pre-prod
         overlay: overlays/pre-prod
-        targetRevision: ArgoCD-v2.4.24-c0_AVP-v1.13.1
+        targetRevision: ArgoCD-v2.6.7-c0_AVP-v1.14.0
       - cluster: beta
         cluster-name: beta
         overlay: overlays/beta
-        targetRevision: ArgoCD-v2.4.24-c0_AVP-v1.13.1
+        targetRevision: ArgoCD-v2.6.7-c0_AVP-v1.14.0
 
   template:
     metadata:


### PR DESCRIPTION
Bump versions:
- ArgoCD 2.6.6 → 2.6.7
- AVP 1.13.1 → 1.14.1