### PR TITLE
fix: add init section

### DIFF
--- a/apps/argocd/base/vault-plugin/vault-plugin-cm.yaml
+++ b/apps/argocd/base/vault-plugin/vault-plugin-cm.yaml
@@ -96,6 +96,8 @@ data:
               then
                 echo "Hit!"
               fi
+      init:
+        command: [sh, -c, "helm dependency update"]  
       generate:
         command:
           - bash

--- a/environments/core/applicationsets/argo-applicationset.yaml
+++ b/environments/core/applicationsets/argo-applicationset.yaml
@@ -9,15 +9,15 @@ spec:
       - cluster: core
         cluster-name: in-cluster
         overlay: overlays/core
-        targetRevision: ArgoCD-v2.6.7-c1_AVP-v1.14.0
+        targetRevision: ArgoCD-v2.6.7-c2_AVP-v1.14.0
       - cluster: hotel-budapest
         cluster-name: hotel-budapest
         overlay: overlays/hotel-budapest
-        targetRevision: ArgoCD-v2.6.7-c1_AVP-v1.14.0
+        targetRevision: ArgoCD-v2.6.7-c2_AVP-v1.14.0
       - cluster: dev
         cluster-name: dev
         overlay: overlays/dev
-        targetRevision: ArgoCD-v2.6.7-c1_AVP-v1.14.0
+        targetRevision: ArgoCD-v2.6.7-c2_AVP-v1.14.0
       - cluster: devsecops-testing
         cluster-name: devsecops-testing
         overlay: overlays/devsecops-testing
@@ -25,11 +25,11 @@ spec:
       - cluster: pre-prod
         cluster-name: pre-prod
         overlay: overlays/pre-prod
-        targetRevision: ArgoCD-v2.6.7-c1_AVP-v1.14.0
+        targetRevision: ArgoCD-v2.6.7-c2_AVP-v1.14.0
       - cluster: beta
         cluster-name: beta
         overlay: overlays/beta
-        targetRevision: ArgoCD-v2.6.7-c1_AVP-v1.14.0
+        targetRevision: ArgoCD-v2.6.7-c2_AVP-v1.14.0
 
   template:
     metadata:


### PR DESCRIPTION
This will fix ArgoCD Apps with no resources, when App source is a helm chart with dependencies.

This fix has been manually applied to DEV/INT/BETA environment to solve issue reported by Lukas Römer.