### PR TITLE
fix: helm_args plugin find fix

### DIFF
--- a/apps/argocd/base/vault-plugin/vault-plugin-cm.yaml
+++ b/apps/argocd/base/vault-plugin/vault-plugin-cm.yaml
@@ -31,7 +31,7 @@ data:
             - sh
             - "-c"
             - >-
-              if [ -n "$(find . -name 'values-*.yaml' | head -1)" ] && 
+              if [ -n "$(find . -name 'values.yaml' | head -1)" ] && 
                  [ -n "$(find . -name 'Chart.yaml' | head -1)" ] &&
                  [ -n "${ARGOCD_ENV_helm_args}" ]; then
                   echo "Hit!"


### PR DESCRIPTION
The plugin shouldn't look for env specific values files in the chart directory. Instead it should look for the default `values.yaml` file. The other parts of the plugin discovery condition is file.