### PR TITLE
feat: add maintenance grafana dashboard

### DIFF
--- a/apps/kube-prometheus-stack/dashboards/maintenance.json
+++ b/apps/kube-prometheus-stack/dashboards/maintenance.json
@@ -25,7 +25,7 @@
     "fiscalYearStartMonth": 0,
     "graphTooltip": 0,
     "id": 29,
-    "iteration": 1680511756693,
+    "iteration": 1680611763996,
     "links": [],
     "liveNow": false,
     "panels": [
@@ -40,7 +40,7 @@
             "id": 8,
             "panels": [],
             "repeat": "release_name",
-            "title": "Release: $release_name",
+            "title": "$release_name",
             "type": "row"
         },
         {
@@ -107,7 +107,7 @@
                     "refId": "A"
                 }
             ],
-            "title": "Resource: $resource_name",
+            "title": "$resource_name",
             "type": "gauge"
         }
     ],
@@ -150,16 +150,10 @@
                 "current": {
                     "selected": true,
                     "text": [
-                        "aks-default-17331370-vmss000000",
-                        "aks-default-17331370-vmss00000a",
-                        "aks-default-17331370-vmss00000b",
-                        "aks-default-17331370-vmss00000c"
+                        "All"
                     ],
                     "value": [
-                        "aks-default-17331370-vmss000000",
-                        "aks-default-17331370-vmss00000a",
-                        "aks-default-17331370-vmss00000b",
-                        "aks-default-17331370-vmss00000c"
+                        "$__all"
                     ]
                 },
                 "datasource": {
@@ -168,7 +162,7 @@
                 },
                 "definition": "label_values(maintenance_app_version_info, resource_name)",
                 "hide": 0,
-                "includeAll": false,
+                "includeAll": true,
                 "multi": true,
                 "name": "resource_name",
                 "options": [],
@@ -192,6 +186,6 @@
     "timezone": "",
     "title": "Maintenance",
     "uid": "y4pgKmB4k",
-    "version": 4,
+    "version": 5,
     "weekStart": ""
 }

--- a/apps/kube-prometheus-stack/dashboards/maintenance.json
+++ b/apps/kube-prometheus-stack/dashboards/maintenance.json
@@ -1,25 +1,25 @@
 {
     "annotations": {
-      "list": [
-        {
-          "builtIn": 1,
-          "datasource": {
-            "type": "grafana",
-            "uid": "-- Grafana --"
-          },
-          "enable": true,
-          "hide": true,
-          "iconColor": "rgba(0, 211, 255, 1)",
-          "name": "Annotations & Alerts",
-          "target": {
-            "limit": 100,
-            "matchAny": false,
-            "tags": [],
-            "type": "dashboard"
-          },
-          "type": "dashboard"
-        }
-      ]
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": {
+                    "type": "grafana",
+                    "uid": "-- Grafana --"
+                },
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "target": {
+                    "limit": 100,
+                    "matchAny": false,
+                    "tags": [],
+                    "type": "dashboard"
+                },
+                "type": "dashboard"
+            }
+        ]
     },
     "editable": true,
     "fiscalYearStartMonth": 0,
@@ -29,164 +29,164 @@
     "links": [],
     "liveNow": false,
     "panels": [
-      {
-        "collapsed": false,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 0
-        },
-        "id": 8,
-        "panels": [],
-        "repeat": "release_name",
-        "title": "Release: $release_name",
-        "type": "row"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "prometheus"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
+        {
+            "collapsed": false,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 0
             },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
+            "id": 8,
+            "panels": [],
+            "repeat": "release_name",
+            "title": "Release: $release_name",
+            "type": "row"
         },
-        "gridPos": {
-          "h": 6,
-          "w": 24,
-          "x": 0,
-          "y": 1
-        },
-        "id": 2,
-        "options": {
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showThresholdLabels": false,
-          "showThresholdMarkers": true,
-          "text": {}
-        },
-        "pluginVersion": "8.5.3",
-        "repeat": "resource_name",
-        "repeatDirection": "v",
-        "targets": [
-          {
+        {
             "datasource": {
-              "type": "prometheus",
-              "uid": "prometheus"
+                "type": "prometheus",
+                "uid": "prometheus"
             },
-            "editorMode": "code",
-            "expr": "maintenance_app_version_info{release_name=\"$release_name\", resource_name=\"$resource_name\"}",
-            "hide": false,
-            "legendFormat": "{{origin}}-{{version_part}}",
-            "range": true,
-            "refId": "A"
-          }
-        ],
-        "title": "Resource: $resource_name",
-        "type": "gauge"
-      }
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 1
+            },
+            "id": 2,
+            "options": {
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "showThresholdLabels": false,
+                "showThresholdMarkers": true,
+                "text": {}
+            },
+            "pluginVersion": "8.5.3",
+            "repeat": "resource_name",
+            "repeatDirection": "v",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "editorMode": "code",
+                    "expr": "maintenance_app_version_info{release_name=\"$release_name\", resource_name=\"$resource_name\"}",
+                    "hide": false,
+                    "legendFormat": "{{origin}}-{{version_part}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Resource: $resource_name",
+            "type": "gauge"
+        }
     ],
     "schemaVersion": 36,
     "style": "dark",
     "tags": [],
     "templating": {
-      "list": [
-        {
-          "current": {
-            "selected": true,
-            "text": [
-              "All"
-            ],
-            "value": [
-              "$__all"
-            ]
-          },
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "definition": "label_values(maintenance_app_version_info, release_name)",
-          "hide": 0,
-          "includeAll": true,
-          "multi": true,
-          "name": "release_name",
-          "options": [],
-          "query": {
-            "query": "label_values(maintenance_app_version_info, release_name)",
-            "refId": "StandardVariableQuery"
-          },
-          "refresh": 1,
-          "regex": "",
-          "skipUrlSync": false,
-          "sort": 0,
-          "type": "query"
-        },
-        {
-          "current": {
-            "selected": true,
-            "text": [
-              "aks-default-17331370-vmss000000",
-              "aks-default-17331370-vmss00000a",
-              "aks-default-17331370-vmss00000b",
-              "aks-default-17331370-vmss00000c"
-            ],
-            "value": [
-              "aks-default-17331370-vmss000000",
-              "aks-default-17331370-vmss00000a",
-              "aks-default-17331370-vmss00000b",
-              "aks-default-17331370-vmss00000c"
-            ]
-          },
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "definition": "label_values(maintenance_app_version_info, resource_name)",
-          "hide": 0,
-          "includeAll": false,
-          "multi": true,
-          "name": "resource_name",
-          "options": [],
-          "query": {
-            "query": "label_values(maintenance_app_version_info, resource_name)",
-            "refId": "StandardVariableQuery"
-          },
-          "refresh": 1,
-          "regex": "",
-          "skipUrlSync": false,
-          "sort": 0,
-          "type": "query"
-        }
-      ]
+        "list": [
+            {
+                "current": {
+                    "selected": true,
+                    "text": [
+                        "All"
+                    ],
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                },
+                "definition": "label_values(maintenance_app_version_info, release_name)",
+                "hide": 0,
+                "includeAll": true,
+                "multi": true,
+                "name": "release_name",
+                "options": [],
+                "query": {
+                    "query": "label_values(maintenance_app_version_info, release_name)",
+                    "refId": "StandardVariableQuery"
+                },
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "type": "query"
+            },
+            {
+                "current": {
+                    "selected": true,
+                    "text": [
+                        "aks-default-17331370-vmss000000",
+                        "aks-default-17331370-vmss00000a",
+                        "aks-default-17331370-vmss00000b",
+                        "aks-default-17331370-vmss00000c"
+                    ],
+                    "value": [
+                        "aks-default-17331370-vmss000000",
+                        "aks-default-17331370-vmss00000a",
+                        "aks-default-17331370-vmss00000b",
+                        "aks-default-17331370-vmss00000c"
+                    ]
+                },
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                },
+                "definition": "label_values(maintenance_app_version_info, resource_name)",
+                "hide": 0,
+                "includeAll": false,
+                "multi": true,
+                "name": "resource_name",
+                "options": [],
+                "query": {
+                    "query": "label_values(maintenance_app_version_info, resource_name)",
+                    "refId": "StandardVariableQuery"
+                },
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "type": "query"
+            }
+        ]
     },
     "time": {
-      "from": "now-5m",
-      "to": "now"
+        "from": "now-5m",
+        "to": "now"
     },
     "timepicker": {},
     "timezone": "",
@@ -194,4 +194,4 @@
     "uid": "y4pgKmB4k",
     "version": 4,
     "weekStart": ""
-  }
+}

--- a/apps/kube-prometheus-stack/dashboards/maintenance.json
+++ b/apps/kube-prometheus-stack/dashboards/maintenance.json
@@ -1,0 +1,197 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "target": {
+            "limit": 100,
+            "matchAny": false,
+            "tags": [],
+            "type": "dashboard"
+          },
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 29,
+    "iteration": 1680511756693,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+      {
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        },
+        "id": 8,
+        "panels": [],
+        "repeat": "release_name",
+        "title": "Release: $release_name",
+        "type": "row"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 6,
+          "w": 24,
+          "x": 0,
+          "y": 1
+        },
+        "id": 2,
+        "options": {
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showThresholdLabels": false,
+          "showThresholdMarkers": true,
+          "text": {}
+        },
+        "pluginVersion": "8.5.3",
+        "repeat": "resource_name",
+        "repeatDirection": "v",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus"
+            },
+            "editorMode": "code",
+            "expr": "maintenance_app_version_info{release_name=\"$release_name\", resource_name=\"$resource_name\"}",
+            "hide": false,
+            "legendFormat": "{{origin}}-{{version_part}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Resource: $resource_name",
+        "type": "gauge"
+      }
+    ],
+    "schemaVersion": 36,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": [
+        {
+          "current": {
+            "selected": true,
+            "text": [
+              "All"
+            ],
+            "value": [
+              "$__all"
+            ]
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "definition": "label_values(maintenance_app_version_info, release_name)",
+          "hide": 0,
+          "includeAll": true,
+          "multi": true,
+          "name": "release_name",
+          "options": [],
+          "query": {
+            "query": "label_values(maintenance_app_version_info, release_name)",
+            "refId": "StandardVariableQuery"
+          },
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 0,
+          "type": "query"
+        },
+        {
+          "current": {
+            "selected": true,
+            "text": [
+              "aks-default-17331370-vmss000000",
+              "aks-default-17331370-vmss00000a",
+              "aks-default-17331370-vmss00000b",
+              "aks-default-17331370-vmss00000c"
+            ],
+            "value": [
+              "aks-default-17331370-vmss000000",
+              "aks-default-17331370-vmss00000a",
+              "aks-default-17331370-vmss00000b",
+              "aks-default-17331370-vmss00000c"
+            ]
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "definition": "label_values(maintenance_app_version_info, resource_name)",
+          "hide": 0,
+          "includeAll": false,
+          "multi": true,
+          "name": "resource_name",
+          "options": [],
+          "query": {
+            "query": "label_values(maintenance_app_version_info, resource_name)",
+            "refId": "StandardVariableQuery"
+          },
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 0,
+          "type": "query"
+        }
+      ]
+    },
+    "time": {
+      "from": "now-5m",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "Maintenance",
+    "uid": "y4pgKmB4k",
+    "version": 4,
+    "weekStart": ""
+  }

--- a/apps/kube-prometheus-stack/templates/dashboards.yaml
+++ b/apps/kube-prometheus-stack/templates/dashboards.yaml
@@ -8,3 +8,5 @@ metadata:
 data:
   logging.json: |
 {{ .Files.Get "dashboards/logging.json" | indent 4 }}
+  maintenance.json: |
+{{ .Files.Get "dashboards/maintenance.json" | indent 4 }}


### PR DESCRIPTION
The feature would configure a new grafana dashboard for the maintenance application. Will test is first on the devsecops-testing cluster.