### PR TITLE
fix: kyverno, prometheus-stack appset plugin setup

### DIFF
--- a/environments/core/applicationsets/kube-prometheus-stack-applicationset.yaml
+++ b/environments/core/applicationsets/kube-prometheus-stack-applicationset.yaml
@@ -34,7 +34,6 @@ spec:
       project: default
       source:
         plugin:
-          name: argocd-vault-plugin-kustomize-helm-args
           env:
             - name: helm_args
               value: '-f values.yaml -f values-{{ cluster }}.yaml'

--- a/environments/core/applicationsets/kyverno-applicationset.yaml
+++ b/environments/core/applicationsets/kyverno-applicationset.yaml
@@ -30,7 +30,9 @@ spec:
       project: default
       source:
         plugin:
-          name: argocd-vault-plugin-kustomize-helm-args
+          env:
+            - name: helm_args
+              value: '-f values.yaml'
         repoURL: https://github.com/catenax-ng/k8s-cluster-stack
         targetRevision: '{{ targetRevision }}'
         path: apps/kyverno


### PR DESCRIPTION
Remove plugin names from the `kyverno` and `kube-prometheus-stack` applicaitonsets to fix them in argocd and use the auto discover feature of the sidecars.