### PR TITLE
chore: new tag ArgoCD-v2.6.7-c5_AVP-v1.14.0

### DIFF
--- a/environments/core/applicationsets/argo-applicationset.yaml
+++ b/environments/core/applicationsets/argo-applicationset.yaml
@@ -9,15 +9,15 @@ spec:
       - cluster: core
         cluster-name: in-cluster
         overlay: overlays/core
-        targetRevision: ArgoCD-v2.6.7-c4_AVP-v1.14.0
+        targetRevision: ArgoCD-v2.6.7-c5_AVP-v1.14.0
       - cluster: hotel-budapest
         cluster-name: hotel-budapest
         overlay: overlays/hotel-budapest
-        targetRevision: ArgoCD-v2.6.7-c4_AVP-v1.14.0
+        targetRevision: ArgoCD-v2.6.7-c5_AVP-v1.14.0
       - cluster: dev
         cluster-name: dev
         overlay: overlays/dev
-        targetRevision: ArgoCD-v2.6.7-c4_AVP-v1.14.0
+        targetRevision: ArgoCD-v2.6.7-c5_AVP-v1.14.0
       - cluster: devsecops-testing
         cluster-name: devsecops-testing
         overlay: overlays/devsecops-testing
@@ -25,11 +25,11 @@ spec:
       - cluster: pre-prod
         cluster-name: pre-prod
         overlay: overlays/pre-prod
-        targetRevision: ArgoCD-v2.6.7-c4_AVP-v1.14.0
+        targetRevision: ArgoCD-v2.6.7-c5_AVP-v1.14.0
       - cluster: beta
         cluster-name: beta
         overlay: overlays/beta
-        targetRevision: ArgoCD-v2.6.7-c4_AVP-v1.14.0
+        targetRevision: ArgoCD-v2.6.7-c5_AVP-v1.14.0
 
   template:
     metadata:


### PR DESCRIPTION
Target revision for clusters changed to ArgoCD-v2.6.7-c5_AVP-v1.14.0