### PR TITLE
Fix/avp helm values sidecar conditions

### DIFF
--- a/apps/argocd/base/vault-plugin/vault-plugin-cm.yaml
+++ b/apps/argocd/base/vault-plugin/vault-plugin-cm.yaml
@@ -63,7 +63,7 @@ data:
             - "-c"
             - >-
               if [ -n "$(find . -name 'values.yaml' | head -1)" ] &&
-                 [ ! -n "$(find . -name 'kustomization.yaml' | head -1)" ] &&
+                 [ -z "$(find . -name 'kustomization.yaml')" ] &&
                  [ -n "$(find . -name 'Chart.yaml' | head -1)" ] &&
                  [ -n "${ARGOCD_ENV_helm_args}" ]; then
                   echo "Hit!"
@@ -94,7 +94,9 @@ data:
             - >-
               if [ -n "$(find . -name 'values.yaml' | head -1)" ] &&
                  [ -n "$(find . -name 'Chart.yaml' | head -1)" ] &&
-                 [ -n "$(find . -name '*.yaml' | xargs -I {} grep '<path\|avp\.kubernetes\.io' {})" ]; 
+                 [ -n "$(find . -name '*.yaml' | xargs -I {} grep '<path\|avp\.kubernetes\.io' {})" ] &&
+                 [ -z "$(find . -name 'kustomization.yaml')" ] &&
+                 [ -z "${ARGOCD_ENV_helm_args}" ]; 
               then
                 echo "Hit!"
               fi

--- a/apps/argocd/overlays/core/configmap/vault-plugin-cm.yaml
+++ b/apps/argocd/overlays/core/configmap/vault-plugin-cm.yaml
@@ -63,7 +63,7 @@ data:
             - "-c"
             - >-
               if [ -n "$(find . -name 'values.yaml' | head -1)" ] &&
-                 [ ! -n "$(find . -name 'kustomization.yaml' | head -1)" ] &&
+                 [ -z "$(find . -name 'kustomization.yaml')" ] &&
                  [ -n "$(find . -name 'Chart.yaml' | head -1)" ] &&
                  [ -n "${ARGOCD_ENV_helm_args}" ]; then
                   echo "Hit!"
@@ -94,7 +94,9 @@ data:
             - >-
               if [ -n "$(find . -name 'values.yaml' | head -1)" ] &&
                  [ -n "$(find . -name 'Chart.yaml' | head -1)" ] &&
-                 [ -n "$(find . -name '*.yaml' | xargs -I {} grep '<path\|avp\.kubernetes\.io' {})" ]; 
+                 [ -n "$(find . -name '*.yaml' | xargs -I {} grep '<path\|avp\.kubernetes\.io' {})" ] &&
+                 [ -z "$(find . -name 'kustomization.yaml')" ] &&
+                 [ -z "${ARGOCD_ENV_helm_args}" ]; 
               then
                 echo "Hit!"
               fi

--- a/environments/core/applicationsets/argo-applicationset.yaml
+++ b/environments/core/applicationsets/argo-applicationset.yaml
@@ -9,15 +9,15 @@ spec:
       - cluster: core
         cluster-name: in-cluster
         overlay: overlays/core
-        targetRevision: ArgoCD-v2.6.7-c6_AVP-v1.14.0
+        targetRevision: ArgoCD-v2.6.7-c7_AVP-v1.14.0
       - cluster: hotel-budapest
         cluster-name: hotel-budapest
         overlay: overlays/hotel-budapest
-        targetRevision: ArgoCD-v2.6.7-c6_AVP-v1.14.0
+        targetRevision: ArgoCD-v2.6.7-c7_AVP-v1.14.0
       - cluster: dev
         cluster-name: dev
         overlay: overlays/dev
-        targetRevision: ArgoCD-v2.6.7-c6_AVP-v1.14.0
+        targetRevision: ArgoCD-v2.6.7-c7_AVP-v1.14.0
       - cluster: devsecops-testing
         cluster-name: devsecops-testing
         overlay: overlays/devsecops-testing
@@ -25,11 +25,11 @@ spec:
       - cluster: pre-prod
         cluster-name: pre-prod
         overlay: overlays/pre-prod
-        targetRevision: ArgoCD-v2.6.7-c6_AVP-v1.14.0
+        targetRevision: ArgoCD-v2.6.7-c7_AVP-v1.14.0
       - cluster: beta
         cluster-name: beta
         overlay: overlays/beta
-        targetRevision: ArgoCD-v2.6.7-c6_AVP-v1.14.0
+        targetRevision: ArgoCD-v2.6.7-c7_AVP-v1.14.0
 
   template:
     metadata:


### PR DESCRIPTION
Add/adjust more conditions to the `avp-helm-values` sidecar plugin, because argocd was hitting the wrong plugin. Changes:

```
[ -z "$(find . -name 'kustomization.yaml')" ] &&
[ -z "${ARGOCD_ENV_helm_args}" ]; 
```

Also bumping `argocd applicatinset` targetrevision.