### PR TITLE
chore: add chatUrl to configmap to enable chat

### DIFF
--- a/apps/argocd/base/argocd-cm.yaml
+++ b/apps/argocd/base/argocd-cm.yaml
@@ -7,4 +7,5 @@ data:
   # Tracking labels are used to determine which resources need to be deleted when pruning.
   # If omitted, Argo CD injects the app name into the label: 'app.kubernetes.io/instance'
   # This might cause problems with Helm charts which will set 'app.kubernetes.io/instance' as well (e.g. Kyverno)
-  application.instanceLabelKey: argocd.argoproj.io/instance
+  application.instanceLabelKey: "argocd.argoproj.io/instance"
+  help.chatUrl: "https://chat.eclipse.org/#/room/#tools.tractus-x:matrix.eclipse.org"


### PR DESCRIPTION
Add `chatUrl` to `argocd-cm` configmap to enable chat via Eclipse Matrix Tractus-X Chat service.