### PR TITLE
chore: remove AVP

### DIFF
--- a/environments/core/applicationsets/certmanager-applicationset.yaml
+++ b/environments/core/applicationsets/certmanager-applicationset.yaml
@@ -39,8 +39,6 @@ spec:
     spec:
       project: default
       source:
-        plugin:
-          name: argocd-vault-plugin-helm
         repoURL: https://github.com/catenax-ng/k8s-cluster-stack
         targetRevision: '{{ targetRevision }}'
         path: apps/certmanager


### PR DESCRIPTION
Remove AVP plugin definition from `source` to get applicationSet back working.