### PR TITLE
fix: add syncOption `ServerSideApply=true`

### DIFF
--- a/environments/core/applicationsets/kube-prometheus-stack-applicationset.yaml
+++ b/environments/core/applicationsets/kube-prometheus-stack-applicationset.yaml
@@ -50,6 +50,7 @@ spec:
       syncPolicy:
         syncOptions:
           - CreateNamespace=true
+          - ServerSideApply=true
         retry:
           limit: 5
           backoff:


### PR DESCRIPTION
Without this option the CDR installation fails with error:
```
one or more objects failed to apply, reason:
  CustomResourceDefinition.apiextensions.k8s.io "prometheuses.monitoring.coreos.com" is invalid:
   metadata.annotations: Too long: must have at most 262144"
...
```

enabling syncOption `serversideapply=true` solves this by running `kubectl apply --server-side ...` instead of `kubectl apply ...`. see [ArgoCD docu](https://argo-cd.readthedocs.io/en/release-2.6/user-guide/sync-options/#server-side-apply).