### PR TITLE
chore: add label and annotation to cert-manager

### DIFF
--- a/apps/certmanager/values.yaml
+++ b/apps/certmanager/values.yaml
@@ -2,3 +2,9 @@
 
 certmanager:
   installCRDs: true
+  
+  serviceLabels:
+    maintenance/scan: "true"
+
+  serviceAnnotations:
+    maintenance/releasename: "cert-manager/cert-manager"


### PR DESCRIPTION
All the apps will be labeled and annotated according to the [maintenance-dashboard readme](https://github.com/catenax-ng/maintenance-dashboard#how-it-works).