### PR TITLE
chore: upgrading argocd to 2.6.10

### DIFF
--- a/apps/argocd/base/kustomization.yaml
+++ b/apps/argocd/base/kustomization.yaml
@@ -7,11 +7,11 @@ namespace: argocd
 # https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/images/
 images:
   - name: quay.io/argoproj/argocd
-    newTag: v2.6.8
+    newTag: v2.6.10
 
 resources:
   - namespace.yaml
-  - https://raw.githubusercontent.com/argoproj/argo-cd/v2.6.8/manifests/ha/install.yaml # ensure to keep images.newTag in sync
+  - https://raw.githubusercontent.com/argoproj/argo-cd/v2.6.10/manifests/ha/install.yaml # ensure to keep images.newTag in sync
   - vault-plugin/vault-plugin-cm.yaml # AVP sidecar configuration
   - avp-rbac-secret-access.yaml # grant avp access to secret with AVP configuration
 

--- a/environments/core/applicationsets/argo-applicationset.yaml
+++ b/environments/core/applicationsets/argo-applicationset.yaml
@@ -9,15 +9,15 @@ spec:
       - cluster: core
         cluster-name: in-cluster
         overlay: overlays/core
-        targetRevision: ArgoCD-v2.6.8-c0_AVP-v1.14.0
+        targetRevision: ArgoCD-v2.6.10-c0_AVP-v1.14.0
       - cluster: hotel-budapest
         cluster-name: hotel-budapest
         overlay: overlays/hotel-budapest
-        targetRevision: ArgoCD-v2.6.8-c0_AVP-v1.14.0
+        targetRevision: ArgoCD-v2.6.10-c0_AVP-v1.14.0
       - cluster: dev
         cluster-name: dev
         overlay: overlays/dev
-        targetRevision: ArgoCD-v2.6.8-c0_AVP-v1.14.0
+        targetRevision: ArgoCD-v2.6.10-c0_AVP-v1.14.0
       - cluster: devsecops-testing
         cluster-name: devsecops-testing
         overlay: overlays/devsecops-testing
@@ -25,15 +25,15 @@ spec:
       - cluster: pre-prod
         cluster-name: pre-prod
         overlay: overlays/pre-prod
-        targetRevision: ArgoCD-v2.6.8-c0_AVP-v1.14.0
+        targetRevision: ArgoCD-v2.6.10-c0_AVP-v1.14.0
       - cluster: beta
         cluster-name: beta
         overlay: overlays/beta
-        targetRevision: ArgoCD-v2.6.8-c0_AVP-v1.14.0
+        targetRevision: ArgoCD-v2.6.10-c0_AVP-v1.14.0
       - cluster: stable
         cluster-name: stable
         overlay: overlays/stable
-        targetRevision: ArgoCD-v2.6.8-c0_AVP-v1.14.0
+        targetRevision: ArgoCD-v2.6.10-c0_AVP-v1.14.0
 
   template:
     metadata:


### PR DESCRIPTION
Upgrading argoCD to latest version 2.6.10