### PR TITLE
chore: revert kube-prometheus applicationset to point to HEAD for DevSecOps testing cluster

### DIFF
--- a/environments/core/applicationsets/kube-prometheus-stack-applicationset.yaml
+++ b/environments/core/applicationsets/kube-prometheus-stack-applicationset.yaml
@@ -17,7 +17,7 @@ spec:
         targetRevision: HEAD
       - cluster: devsecops-testing
         cluster-name: devsecops-testing
-        targetRevision: chore/prometheus-upgrade 
+        targetRevision: HEAD
       - cluster: pre-prod
         cluster-name: pre-prod
         targetRevision: HEAD


### PR DESCRIPTION
…secops cluster