### PR TITLE
feat(dashboard): add dashboard for portal service overview

### DIFF
--- a/apps/kube-prometheus-stack/dashboards/portal.json
+++ b/apps/kube-prometheus-stack/dashboards/portal.json
@@ -1,0 +1,451 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 1,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "aedbd012-3eb3-4765-af97-52881ff06fe1"
+      },
+      "description": "Count of errors for each given container",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisGridShow": true,
+            "axisLabel": "Count",
+            "axisPlacement": "left",
+            "barAlignment": 0,
+            "drawStyle": "points",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 3,
+            "pointSize": 10,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 79.9995
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "aedbd012-3eb3-4765-af97-52881ff06fe1"
+          },
+          "editorMode": "code",
+          "expr": "sum by(container) (count_over_time({container=~\"administration-service|marketplace-app-service|processes-worker|notification-service|registration-service|services-service\"} |= `Level` | json log | __error__=`` | line_format `{{.log}}` | json | __error__=`` | unpack  | Level = `Error` [$__interval]))",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Errors",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "aedbd012-3eb3-4765-af97-52881ff06fe1"
+      },
+      "description": "Count of errors for each given container",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisGridShow": true,
+            "axisLabel": "Count",
+            "axisPlacement": "left",
+            "barAlignment": 0,
+            "drawStyle": "points",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 3,
+            "pointSize": 10,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 79.9995
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "aedbd012-3eb3-4765-af97-52881ff06fe1"
+          },
+          "editorMode": "builder",
+          "expr": "sum by(Properties_StatusCode, container) (count_over_time({container=~\"administration-service|marketplace-app-service|processes-worker|notification-service|registration-service|services-service\"} |= `Level` | json log | __error__=`` | line_format `{{.log}}` | json | __error__=`` | unpack | Level = `Error` [$__interval]))",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Error Count by StatusCode",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "aedbd012-3eb3-4765-af97-52881ff06fe1"
+      },
+      "description": "Count of warnings for each given container",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisGridShow": true,
+            "axisLabel": "Count",
+            "axisPlacement": "left",
+            "barAlignment": 0,
+            "drawStyle": "points",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 3,
+            "pointSize": 10,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 79.9995
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "aedbd012-3eb3-4765-af97-52881ff06fe1"
+          },
+          "editorMode": "code",
+          "expr": "sum by(container) (count_over_time({container=~\"administration-service|marketplace-app-service|processes-worker|notification-service|registration-service|services-service\"} |= `Level` | json log | __error__=`` | line_format `{{.log}}` | json | __error__=`` | unpack  | Level = `Warning` [$__interval]))",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Warnings",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "aedbd012-3eb3-4765-af97-52881ff06fe1"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Elapsed in ms",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1999.9998
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "{}"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "aedbd012-3eb3-4765-af97-52881ff06fe1"
+          },
+          "editorMode": "code",
+          "expr": "sum by(Properties_Elapsed) (avg_over_time({container=~\"administration-service|marketplace-app-service|processes-worker|notification-service|registration-service|services-service\"} |= `Elapsed` | json log | __error__=`` | line_format `{{.log}}` | json | __error__=`` | unwrap Properties_Elapsed | __error__=`` [$__interval]) by (container))",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Elapsed time",
+      "transformations": [],
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Portal",
+  "uid": "bd886d0a-492c-47e8-b4a5-b389814598d7",
+  "version": 3,
+  "weekStart": ""
+}

--- a/apps/kube-prometheus-stack/dashboards/product-portal.json
+++ b/apps/kube-prometheus-stack/dashboards/product-portal.json
@@ -141,7 +141,7 @@
             "uid": "${DS_LOKI}"
           },
           "editorMode": "code",
-          "expr": "sum by(container) (count_over_time({container=~\"administration-service|marketplace-app-service|processes-worker|notification-service|registration-service|services-service\"} |= `Level` | json log | __error__=`` | line_format `{{.log}}` | json | __error__=`` | unpack  | Level = `Error` [$__interval]))",
+          "expr": "sum by(container) (count_over_time({container=~\"administration-service|marketplace-app-service|processes-worker|notification-service|registration-service|services-service\"} |= `Level` | json | __error__=`` | unpack  | Level = `Error` [$__interval]))",
           "queryType": "range",
           "refId": "A"
         }
@@ -237,8 +237,8 @@
             "type": "loki",
             "uid": "${DS_LOKI}"
           },
-          "editorMode": "builder",
-          "expr": "sum by(Properties_StatusCode, container) (count_over_time({container=~\"administration-service|marketplace-app-service|processes-worker|notification-service|registration-service|services-service\"} |= `Level` | json log | __error__=`` | line_format `{{.log}}` | json | __error__=`` | unpack | Level = `Error` [$__interval]))",
+          "editorMode": "code",
+          "expr": "sum by(Properties_StatusCode, container) (count_over_time({container=~\"administration-service|marketplace-app-service|notification-service|registration-service|services-service\"} |= `Level` | json | __error__=`` | unpack | Level = `Error` [$__interval]))",
           "queryType": "range",
           "refId": "A"
         }
@@ -335,7 +335,7 @@
             "uid": "${DS_LOKI}"
           },
           "editorMode": "code",
-          "expr": "sum by(container) (count_over_time({container=~\"administration-service|marketplace-app-service|processes-worker|notification-service|registration-service|services-service\"} |= `Level` | json log | __error__=`` | line_format `{{.log}}` | json | __error__=`` | unpack  | Level = `Warning` [$__interval]))",
+          "expr": "sum by(container) (count_over_time({container=~\"administration-service|marketplace-app-service|processes-worker|notification-service|registration-service|services-service\"} |= `Level` | json | __error__=`` | unpack  | Level = `Warning` [$__interval]))",
           "queryType": "range",
           "refId": "A"
         }
@@ -452,7 +452,7 @@
             "uid": "${DS_LOKI}"
           },
           "editorMode": "code",
-          "expr": "sum by(Properties_Elapsed) (avg_over_time({container=~\"administration-service|marketplace-app-service|processes-worker|notification-service|registration-service|services-service\"} |= `Elapsed` | json log | __error__=`` | line_format `{{.log}}` | json | __error__=`` | unwrap Properties_Elapsed | __error__=`` [$__interval]) by (container))",
+          "expr": "sum by(Properties_Elapsed) (avg_over_time({container=~\"administration-service|marketplace-app-service|processes-worker|notification-service|registration-service|services-service\"} |= `Elapsed` | json | __error__=`` | unwrap Properties_Elapsed | __error__=`` [$__interval]) by (container))",
           "queryType": "range",
           "refId": "A"
         }
@@ -470,13 +470,13 @@
     "list": []
   },
   "time": {
-    "from": "now-24h",
+    "from": "now-30m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Product Portal",
   "uid": "bd886d0a-492c-47e8-b4a5-b389814598d7",
-  "version": 3,
+  "version": 5,
   "weekStart": ""
 }

--- a/apps/kube-prometheus-stack/dashboards/product-portal.json
+++ b/apps/kube-prometheus-stack/dashboards/product-portal.json
@@ -1,4 +1,35 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_LOKI",
+      "label": "Loki",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "loki",
+      "pluginName": "Loki"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "9.5.2"
+    },
+    {
+      "type": "datasource",
+      "id": "loki",
+      "name": "Loki",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -18,14 +49,14 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 1,
+  "id": null,
   "links": [],
   "liveNow": false,
   "panels": [
     {
       "datasource": {
         "type": "loki",
-        "uid": "aedbd012-3eb3-4765-af97-52881ff06fe1"
+        "uid": "${DS_LOKI}"
       },
       "description": "Count of errors for each given container",
       "fieldConfig": {
@@ -107,7 +138,7 @@
         {
           "datasource": {
             "type": "loki",
-            "uid": "aedbd012-3eb3-4765-af97-52881ff06fe1"
+            "uid": "${DS_LOKI}"
           },
           "editorMode": "code",
           "expr": "sum by(container) (count_over_time({container=~\"administration-service|marketplace-app-service|processes-worker|notification-service|registration-service|services-service\"} |= `Level` | json log | __error__=`` | line_format `{{.log}}` | json | __error__=`` | unpack  | Level = `Error` [$__interval]))",
@@ -122,7 +153,7 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "aedbd012-3eb3-4765-af97-52881ff06fe1"
+        "uid": "${DS_LOKI}"
       },
       "description": "Count of errors for each given container",
       "fieldConfig": {
@@ -204,7 +235,7 @@
         {
           "datasource": {
             "type": "loki",
-            "uid": "aedbd012-3eb3-4765-af97-52881ff06fe1"
+            "uid": "${DS_LOKI}"
           },
           "editorMode": "builder",
           "expr": "sum by(Properties_StatusCode, container) (count_over_time({container=~\"administration-service|marketplace-app-service|processes-worker|notification-service|registration-service|services-service\"} |= `Level` | json log | __error__=`` | line_format `{{.log}}` | json | __error__=`` | unpack | Level = `Error` [$__interval]))",
@@ -219,7 +250,7 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "aedbd012-3eb3-4765-af97-52881ff06fe1"
+        "uid": "${DS_LOKI}"
       },
       "description": "Count of warnings for each given container",
       "fieldConfig": {
@@ -301,7 +332,7 @@
         {
           "datasource": {
             "type": "loki",
-            "uid": "aedbd012-3eb3-4765-af97-52881ff06fe1"
+            "uid": "${DS_LOKI}"
           },
           "editorMode": "code",
           "expr": "sum by(container) (count_over_time({container=~\"administration-service|marketplace-app-service|processes-worker|notification-service|registration-service|services-service\"} |= `Level` | json log | __error__=`` | line_format `{{.log}}` | json | __error__=`` | unpack  | Level = `Warning` [$__interval]))",
@@ -316,7 +347,7 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "aedbd012-3eb3-4765-af97-52881ff06fe1"
+        "uid": "${DS_LOKI}"
       },
       "fieldConfig": {
         "defaults": {
@@ -418,7 +449,7 @@
         {
           "datasource": {
             "type": "loki",
-            "uid": "aedbd012-3eb3-4765-af97-52881ff06fe1"
+            "uid": "${DS_LOKI}"
           },
           "editorMode": "code",
           "expr": "sum by(Properties_Elapsed) (avg_over_time({container=~\"administration-service|marketplace-app-service|processes-worker|notification-service|registration-service|services-service\"} |= `Elapsed` | json log | __error__=`` | line_format `{{.log}}` | json | __error__=`` | unwrap Properties_Elapsed | __error__=`` [$__interval]) by (container))",
@@ -439,7 +470,7 @@
     "list": []
   },
   "time": {
-    "from": "now-3h",
+    "from": "now-24h",
     "to": "now"
   },
   "timepicker": {},

--- a/apps/kube-prometheus-stack/dashboards/product-portal.json
+++ b/apps/kube-prometheus-stack/dashboards/product-portal.json
@@ -475,7 +475,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Portal",
+  "title": "Product Portal",
   "uid": "bd886d0a-492c-47e8-b4a5-b389814598d7",
   "version": 3,
   "weekStart": ""

--- a/apps/kube-prometheus-stack/templates/dashboards.yaml
+++ b/apps/kube-prometheus-stack/templates/dashboards.yaml
@@ -10,3 +10,5 @@ data:
 {{ .Files.Get "dashboards/logging.json" | indent 4 }}
   maintenance.json: |
 {{ .Files.Get "dashboards/maintenance.json" | indent 4 }}
+  portal.json: |
+{{ .Files.Get "dashboards/portal.json" | indent 4 }}

--- a/apps/kube-prometheus-stack/templates/dashboards.yaml
+++ b/apps/kube-prometheus-stack/templates/dashboards.yaml
@@ -10,5 +10,5 @@ data:
 {{ .Files.Get "dashboards/logging.json" | indent 4 }}
   maintenance.json: |
 {{ .Files.Get "dashboards/maintenance.json" | indent 4 }}
-  portal.json: |
-{{ .Files.Get "dashboards/portal.json" | indent 4 }}
+  product-portal.json: |
+{{ .Files.Get "dashboards/product-portal.json" | indent 4 }}


### PR DESCRIPTION
## Description

Added a dashboard to display the following data for the portal services:
    - the last errors that occured
    - the amount of errors per statusCode
    - the warnings that occured
    - the avg elapsed time of the requests per service

## Why

To have a better overview of the errors and warnings that appear within the portal services

## Issue

N/A - Jira Issue: CPLP-1849

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally

