### PR TITLE
chore: add kubeapps helm chart with initial config

### DIFF
--- a/apps/kubeapps/Chart.yaml
+++ b/apps/kubeapps/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: kubeapps
+description: Kubeapps to deploy helm charts in the cluster
+type: application
+version: 0.0.1
+appVersion: "0.0.1"
+
+dependencies:
+- name: kubeapps
+  alias: kubeapps
+  version: 12.4.7
+  repository: https://charts.bitnami.com/bitnami

--- a/apps/kubeapps/values.yaml
+++ b/apps/kubeapps/values.yaml
@@ -1,0 +1,15 @@
+kubeapps:
+  authProxy:
+    enabled: true
+    provider: github
+    scope: 'openid email groups user:email'
+    clientID: '<path:/devsecops/data/clusters/devsecops-testing/github-oauth#kubeappsOAuthClientId>'
+    clientSecret: '<path:/devsecops/data/clusters/devsecops-testing/github-oauth#kubeappsOAuthClientSecret>'
+    cookieSecret: '<path:/devsecops/data/clusters/devsecops-testing/github-oauth#kubeappsOAuthCookieSecret>'
+  ingress:
+    enabled: true
+    hostname: kubeapps-test.devsecops-testing.demo.catena-x.net
+    extraTls:
+    - hosts:
+      - kubeapps-test.devsecops-testing.demo.catena-x.net
+      secretName: tls-secret


### PR DESCRIPTION
This PR will add Kubeapps to the cluster tooling. Currently contains a basic configuration that needs to be modified for each cluster with a separate `values.yaml`.

NOTE: Vault secrets will need to be generated for each cluster as it is currently done for the devsecops-testing cluster.