### PR TITLE
fix: update path to a file keeping AVP version

### DIFF
--- a/apps/argocd/README.md
+++ b/apps/argocd/README.md
@@ -67,7 +67,7 @@ Hey, there's a new ArgoCD version, then follow these steps:
 
 - Create a new branch from `main`, e.g. `chore/bump_avp_version`
 - Checkout new branch
-- ArgoCD Vault Plugin version has to be updated in `apps/argocd/base/plugins/argo-vault-plugin.yaml`
+- ArgoCD Vault Plugin version has to be updated in `apps/argocd/base/vault-plugin/argo-repo-server-sidecars.yaml` 
 
   ```yaml
   initContainers:


### PR DESCRIPTION
Documentation seems to be outdated and the file path link doesn't work anymore, giving 404.
Fixing that with a proper yaml path.