### PR TITLE
chore:  applicationset update for devsecops-testing cluster certmanager upgrade

### DIFF
--- a/environments/core/applicationsets/certmanager-applicationset.yaml
+++ b/environments/core/applicationsets/certmanager-applicationset.yaml
@@ -20,7 +20,7 @@ spec:
         targetRevision: HEAD
       - cluster: devsecops-testing
         cluster-name: devsecops-testing
-        targetRevision: HEAD
+        targetRevision: chore/certmanager-upgrade-devsecopscluster
       - cluster: pre-prod
         cluster-name: pre-prod
         targetRevision: HEAD


### PR DESCRIPTION
Fixes https://github.com/eclipse-tractusx/sig-infra/issues/195