### PR TITLE
chore: certmanager upgrade to 1.12.2 on all clusters

### DIFF
--- a/apps/certmanager/Chart.yaml
+++ b/apps/certmanager/Chart.yaml
@@ -26,5 +26,5 @@ appVersion: "1.16.0"
 dependencies:
 - name: cert-manager
   alias: certmanager
-  version: 1.10.0
+  version: 1.12.2
   repository: https://charts.jetstack.io

--- a/environments/core/applicationsets/certmanager-applicationset.yaml
+++ b/environments/core/applicationsets/certmanager-applicationset.yaml
@@ -20,7 +20,7 @@ spec:
         targetRevision: HEAD
       - cluster: devsecops-testing
         cluster-name: devsecops-testing
-        targetRevision: chore/certmanager-upgrade-devsecopscluster
+        targetRevision: HEAD
       - cluster: pre-prod
         cluster-name: pre-prod
         targetRevision: HEAD


### PR DESCRIPTION
Fixes https://github.com/eclipse-tractusx/sig-infra/issues/195