### PR TITLE
chore: ingress upgrade

### DIFF
--- a/apps/ingress-nginx/Chart.yaml
+++ b/apps/ingress-nginx/Chart.yaml
@@ -26,5 +26,5 @@ appVersion: "1.16.0"
 dependencies:
 - name: ingress-nginx
   alias: ingress-nginx
-  version: 4.5.2
+  version: 4.7.1
   repository: https://kubernetes.github.io/ingress-nginx

--- a/environments/core/applicationsets/ingress-applicationset.yaml
+++ b/environments/core/applicationsets/ingress-applicationset.yaml
@@ -20,7 +20,7 @@ spec:
         targetRevision: HEAD
       - cluster: devsecops-testing
         cluster-name: devsecops-testing
-        targetRevision: chore/ingress-upgrade-devsecopscluster
+        targetRevision: HEAD
       - cluster: pre-prod
         cluster-name: pre-prod
         targetRevision: HEAD


### PR DESCRIPTION
- ingress-nginx upgrade to 4.7.1 on all clusters
- revert ingress applicationset targetRevision to HEAD for devsecops-testing cluster

Updates https://github.com/eclipse-tractusx/sig-infra/issues/200