### PR TITLE
chore: update argocd to 2.7 and avp to 1.16.1

### DIFF
--- a/apps/argocd/base/kustomization.yaml
+++ b/apps/argocd/base/kustomization.yaml
@@ -7,11 +7,11 @@ namespace: argocd
 # https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/images/
 images:
   - name: quay.io/argoproj/argocd
-    newTag: v2.6.13
+    newTag: v2.7.13
 
 resources:
   - namespace.yaml
-  - https://raw.githubusercontent.com/argoproj/argo-cd/v2.6.13/manifests/ha/install.yaml # ensure to keep images.newTag in sync
+  - https://raw.githubusercontent.com/argoproj/argo-cd/v2.7.13/manifests/ha/install.yaml # ensure to keep images.newTag in sync
   - vault-plugin/vault-plugin-cm.yaml # AVP sidecar configuration
   - avp-rbac-secret-access.yaml # grant avp access to secret with AVP configuration
 

--- a/apps/argocd/base/vault-plugin/argo-repo-server-sidecars.yaml
+++ b/apps/argocd/base/vault-plugin/argo-repo-server-sidecars.yaml
@@ -30,7 +30,7 @@ spec:
           image: registry.access.redhat.com/ubi8
           env:
             - name: AVP_VERSION
-              value: 1.14.0
+              value: 1.16.1
           command: [sh, -c]
           args:
             - >-
@@ -45,7 +45,7 @@ spec:
         # argocd-vault-plugin with Helm values
         - name: avp-helm-values
           command: [ /var/run/argocd/argocd-cmp-server ]
-          image: quay.io/argoproj/argocd:v2.6.6
+          image: quay.io/argoproj/argocd:v2.7.13
           securityContext:
             runAsNonRoot: true
             runAsUser: 999
@@ -70,7 +70,7 @@ spec:
         # argocd-vault-plugin with Helm args
         - name: avp-helm-args
           command: [ /var/run/argocd/argocd-cmp-server ]
-          image: quay.io/argoproj/argocd:v2.6.6
+          image: quay.io/argoproj/argocd:v2.7.13
           securityContext:
             runAsNonRoot: true
             runAsUser: 999
@@ -95,7 +95,7 @@ spec:
         # argocd-vault-plugin with Kustomize
         - name: avp-kustomize
           command: [/var/run/argocd/argocd-cmp-server]
-          image: quay.io/argoproj/argocd:v2.6.6
+          image: quay.io/argoproj/argocd:v2.7.13
           securityContext:
             runAsNonRoot: true
             runAsUser: 999
@@ -120,7 +120,7 @@ spec:
         # argocd-vault-plugin with Kustomize and Helm
         - name: avp-helm-kustomize
           command: [ /var/run/argocd/argocd-cmp-server ]
-          image: quay.io/argoproj/argocd:v2.6.6
+          image: quay.io/argoproj/argocd:v2.7.13
           securityContext:
             runAsNonRoot: true
             runAsUser: 999
@@ -145,7 +145,7 @@ spec:
         # argocd-vault-plugin with plain YAML
         - name: avp
           command: [/var/run/argocd/argocd-cmp-server]
-          image: quay.io/argoproj/argocd:v2.6.6
+          image: quay.io/argoproj/argocd:v2.7.13
           securityContext:
             runAsNonRoot: true
             runAsUser: 999

--- a/environments/core/applicationsets/argo-applicationset.yaml
+++ b/environments/core/applicationsets/argo-applicationset.yaml
@@ -9,15 +9,15 @@ spec:
       - cluster: core
         cluster-name: in-cluster
         overlay: overlays/core
-        targetRevision: ArgoCD-v2.6.13-c0_AVP-v1.14.0
+        targetRevision: ArgoCD-v2.7.13-c0_AVP-v1.16.1
       - cluster: hotel-budapest
         cluster-name: hotel-budapest
         overlay: overlays/hotel-budapest
-        targetRevision: ArgoCD-v2.6.13-c0_AVP-v1.14.0
+        targetRevision: ArgoCD-v2.7.13-c0_AVP-v1.16.1
       - cluster: dev
         cluster-name: dev
         overlay: overlays/dev
-        targetRevision: ArgoCD-v2.6.13-c0_AVP-v1.14.0
+        targetRevision: ArgoCD-v2.7.13-c0_AVP-v1.16.1
       - cluster: devsecops-testing
         cluster-name: devsecops-testing
         overlay: overlays/devsecops-testing
@@ -25,15 +25,15 @@ spec:
       - cluster: pre-prod
         cluster-name: pre-prod
         overlay: overlays/pre-prod
-        targetRevision: ArgoCD-v2.6.13-c0_AVP-v1.14.0
+        targetRevision: ArgoCD-v2.7.13-c0_AVP-v1.16.1
       - cluster: beta
         cluster-name: beta
         overlay: overlays/beta
-        targetRevision: ArgoCD-v2.6.13-c0_AVP-v1.14.0
+        targetRevision: ArgoCD-v2.7.13-c0_AVP-v1.16.1
       - cluster: stable
         cluster-name: stable
         overlay: overlays/stable
-        targetRevision: ArgoCD-v2.6.13-c0_AVP-v1.14.0
+        targetRevision: ArgoCD-v2.7.13-c0_AVP-v1.16.1
 
   template:
     metadata:


### PR DESCRIPTION
Update ArgoCD minor version from 2.6 to 2.7. Stages will be updated after GH tag ArgoCD-v2.7.13-c0_AVP-v1.16.1 is available. The tag will be available after test has been finished on devsecops-testing-cluster

Upgrading info:
https://argo-cd.readthedocs.io/en/stable/operator-manual/upgrading/2.6-2.7/

What's new in ArgoCD 2.7:
https://www.youtube.com/watch?v=00KxYdJKrSo

System team ticket: https://github.com/eclipse-tractusx/sig-infra/issues/239