### PR TITLE
chore: update ArgoCD config to prepare kyverno deployment

### DIFF
--- a/apps/argocd/base/argocd-cm.yaml
+++ b/apps/argocd/base/argocd-cm.yaml
@@ -9,3 +9,16 @@ data:
   # This might cause problems with Helm charts which will set 'app.kubernetes.io/instance' as well (e.g. Kyverno)
   application.instanceLabelKey: "argocd.argoproj.io/instance"
   help.chatUrl: "https://chat.eclipse.org/#/room/#tools.tractus-x:matrix.eclipse.org"
+
+  # exclude Kyverno resources according to recommendation in Kyverno documentation
+  # https://github.com/kyverno/kyverno/blob/release-1.10/charts/kyverno/README.md?plain=1#L53-L84
+  resource.exclusions: |
+    - apiGroups:
+        - kyverno.io
+      kinds:
+        - AdmissionReport
+        - BackgroundScanReport
+        - ClusterAdmissionReport
+        - ClusterBackgroundScanReport
+      clusters:
+        - '*'

--- a/environments/core/applicationsets/kyverno-applicationset.yaml
+++ b/environments/core/applicationsets/kyverno-applicationset.yaml
@@ -8,7 +8,7 @@ spec:
         elements:
           - cluster: devsecops-testing
             cluster-name: devsecops-testing
-            targetRevision: HEAD
+            targetRevision: chore/upgrade-kyverno-to-v1.10 # pin to feature branch for testing purpose
           - cluster: dev
             cluster-name: dev
             targetRevision: HEAD
@@ -48,7 +48,7 @@ spec:
       syncPolicy:
         # disabled autoSync with A1ODT-461 to avoid accidental damage to Hotel Budapest
         # https://github.com/kyverno/kyverno/tree/main/charts/kyverno
-       # automated: # automated sync by default retries failed attempts 5 times with following delays between attempts ( 5s, 10s, 20s, 40s, 80s ); retry controlled using `retry` field.
+        # automated: # automated sync by default retries failed attempts 5 times with following delays between attempts ( 5s, 10s, 20s, 40s, 80s ); retry controlled using `retry` field.
         #  prune: true # Specifies if resources should be pruned during auto-syncing ( false by default ).
         #  selfHeal: true # Specifies if partial app sync should be executed when resources are changed only in target Kubernetes cluster and no git change detected ( false by default ).
         #          allowEmpty: false # Allows deleting all application resources during automatic syncing ( false by default ).


### PR DESCRIPTION
Add Kyverno specific settings to `argocd-cm` confimap and point DevSecOps-Testing Cluster to a branch to install Kyverno from. 

Related to eclipse-tractusx/sig-infra#315