### PR TITLE
chore: bump targetRevision due to config changes

### DIFF
--- a/environments/core/applicationsets/argo-applicationset.yaml
+++ b/environments/core/applicationsets/argo-applicationset.yaml
@@ -9,15 +9,15 @@ spec:
       - cluster: core
         cluster-name: in-cluster
         overlay: overlays/core
-        targetRevision: ArgoCD-v2.7.14-c0_AVP-v1.16.1
+        targetRevision: ArgoCD-v2.7.14-c1_AVP-v1.16.1
       - cluster: hotel-budapest
         cluster-name: hotel-budapest
         overlay: overlays/hotel-budapest
-        targetRevision: ArgoCD-v2.7.14-c0_AVP-v1.16.1
+        targetRevision: ArgoCD-v2.7.14-c1_AVP-v1.16.1
       - cluster: dev
         cluster-name: dev
         overlay: overlays/dev
-        targetRevision: ArgoCD-v2.7.14-c0_AVP-v1.16.1
+        targetRevision: ArgoCD-v2.7.14-c1_AVP-v1.16.1
       - cluster: devsecops-testing
         cluster-name: devsecops-testing
         overlay: overlays/devsecops-testing
@@ -25,15 +25,15 @@ spec:
       - cluster: pre-prod
         cluster-name: pre-prod
         overlay: overlays/pre-prod
-        targetRevision: ArgoCD-v2.7.14-c0_AVP-v1.16.1
+        targetRevision: ArgoCD-v2.7.14-c1_AVP-v1.16.1
       - cluster: beta
         cluster-name: beta
         overlay: overlays/beta
-        targetRevision: ArgoCD-v2.7.14-c0_AVP-v1.16.1
+        targetRevision: ArgoCD-v2.7.14-c1_AVP-v1.16.1
       - cluster: stable
         cluster-name: stable
         overlay: overlays/stable
-        targetRevision: ArgoCD-v2.7.14-c0_AVP-v1.16.1
+        targetRevision: ArgoCD-v2.7.14-c1_AVP-v1.16.1
 
   template:
     metadata:


### PR DESCRIPTION
Of corse I missed to bump the targetRevision for ArgoCD applicationset to enable the changes from previous PR #424.

GH Tag does not yet exists and will be created on the merge commit and pushed to main branch after this PR has been merged.