### PR TITLE
chore: refactor avp setup

### DIFF
--- a/apps/argocd/base/vault-plugin/argo-repo-server-sidecars.yaml
+++ b/apps/argocd/base/vault-plugin/argo-repo-server-sidecars.yaml
@@ -8,7 +8,6 @@ spec:
       app.kubernetes.io/name: argocd-repo-server
   template:
     spec:
-
       # Mount SA token for Kubernets auth
       # Note: In 2.4.0 onward, there is a dedicated SA for repo-server (not default)
       # Note: This is not fully supported for Kubernetes < v1.19
@@ -22,7 +21,7 @@ spec:
         - name: custom-tools
           emptyDir: {}
         - name: cmp-tmp
-          emptyDir: { }
+          emptyDir: {}
 
       # Download tools
       initContainers:
@@ -118,29 +117,29 @@ spec:
               mountPath: /usr/local/bin/argocd-vault-plugin
 
         # argocd-vault-plugin with Kustomize and Helm
-        - name: avp-helm-kustomize
-          command: [ /var/run/argocd/argocd-cmp-server ]
-          image: quay.io/argoproj/argocd:v2.7.13
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 999
-          volumeMounts:
-            - mountPath: /var/run/argocd
-              name: var-files
-            - mountPath: /home/argocd/cmp-server/plugins
-              name: plugins
-            - mountPath: /tmp
-              name: cmp-tmp
-
-            # Register plugins into sidecar
-            - mountPath: /home/argocd/cmp-server/config/plugin.yaml
-              subPath: avp-helm-kustomize.yaml
-              name: cmp-plugin
-
-            # Important: Mount tools into $PATH
-            - name: custom-tools
-              subPath: argocd-vault-plugin
-              mountPath: /usr/local/bin/argocd-vault-plugin
+#        - name: avp-helm-kustomize
+#          command: [ /var/run/argocd/argocd-cmp-server ]
+#          image: quay.io/argoproj/argocd:v2.7.13
+#          securityContext:
+#            runAsNonRoot: true
+#            runAsUser: 999
+#          volumeMounts:
+#            - mountPath: /var/run/argocd
+#              name: var-files
+#            - mountPath: /home/argocd/cmp-server/plugins
+#              name: plugins
+#            - mountPath: /tmp
+#              name: cmp-tmp
+#
+#            # Register plugins into sidecar
+#            - mountPath: /home/argocd/cmp-server/config/plugin.yaml
+#              subPath: avp-helm-kustomize.yaml
+#              name: cmp-plugin
+#
+#            # Important: Mount tools into $PATH
+#            - name: custom-tools
+#              subPath: argocd-vault-plugin
+#              mountPath: /usr/local/bin/argocd-vault-plugin
 
         # argocd-vault-plugin with plain YAML
         - name: avp

--- a/apps/argocd/base/vault-plugin/vault-plugin-cm.yaml
+++ b/apps/argocd/base/vault-plugin/vault-plugin-cm.yaml
@@ -3,51 +3,6 @@ kind: ConfigMap
 metadata:
   name: cmp-plugin
 data:
-  avp-kustomize.yaml: |
-    ---
-    apiVersion: argoproj.io/v1alpha1
-    kind: ConfigManagementPlugin
-    metadata:
-      name: argocd-vault-plugin-kustomize
-    spec:
-      allowConcurrency: true
-      discover:
-        find:
-          command: [sh, -c, "find . -name kustomization.yaml"] 
-      generate:
-        command: [sh, -c, "kustomize build . | argocd-vault-plugin generate - -s $ARGOCD_APP_NAMESPACE:vault-secret"]
-      lockRepo: false
-  avp-helm-kustomize.yaml: |
-    ---
-    apiVersion: argoproj.io/v1alpha1
-    kind: ConfigManagementPlugin
-    metadata:
-      name: argocd-vault-plugin-kustomize-helm-args
-    spec:
-      allowConcurrency: true
-      discover:
-        find:
-          command:
-            - sh
-            - "-c"
-            - |
-              if [ -n "$(find . -name 'values.yaml' | head -1)" ] &&
-                 [ -n "$(find . -name 'Chart.yaml' | head -1)" ] && 
-                 [ -n "$(find . -name 'kustomization.yaml' | head -1)" ] &&
-                 [ -n "${ARGOCD_ENV_helm_args}" ]; then
-                  echo "Hit!"
-              fi
-      init:
-        command: [sh, -c, "helm dependency update"]
-      generate:
-        command:
-          - sh
-          - "-c"
-          - >-
-            helm template $ARGOCD_APP_NAME --include-crds -n $ARGOCD_APP_NAMESPACE ${ARGOCD_ENV_helm_args} . > manifest.yaml && 
-            kustomize build | 
-            argocd-vault-plugin generate - -s $ARGOCD_APP_NAMESPACE:vault-secret
-      lockRepo: false
   avp-helm-args.yaml: |
     ---
     apiVersion: argoproj.io/v1alpha1
@@ -61,20 +16,20 @@ data:
           command:
             - sh
             - "-c"
-            - >-
-              if [ -n "$(find . -name 'values.yaml' | head -1)" ] &&
-                 [ -z "$(find . -name 'kustomization.yaml')" ] &&
-                 [ -n "$(find . -name 'Chart.yaml' | head -1)" ] &&
-                 [ -n "${ARGOCD_ENV_helm_args}" ]; then
-                  echo "Hit!"
+            - |
+              if [ -n "$(find . -name 'Chart.yaml')" ] && # if find output is nonzero
+                [ -n "$(find . -name 'values.yaml')" ] && # if find output is nonzero
+                [ -n "${ARGOCD_ENV_helm_args}" ]; # if var ARGOCD_ENV_helm_args is defined and nonzero
+              then
+                echo "ARGOCD_ENV_helm_args!"
               fi
       init:
-        command: [sh, -c, "helm dependency update"]
+        command: [ sh, -c, "helm dependency update" ]
       generate:
         command:
           - bash
           - "-c"
-          - >-
+          - |
             helm template $ARGOCD_APP_NAME --include-crds -n $ARGOCD_APP_NAMESPACE $ARGOCD_ENV_helm_args . |
             argocd-vault-plugin generate - -s $ARGOCD_APP_NAMESPACE:vault-secret
       lockRepo: false
@@ -83,7 +38,7 @@ data:
     apiVersion: argoproj.io/v1alpha1
     kind: ConfigManagementPlugin
     metadata:
-      name: argocd-vault-plugin-helm
+      name: argocd-vault-plugin-helm-values
     spec:
       allowConcurrency: true
       discover:
@@ -91,24 +46,36 @@ data:
           command:
             - sh
             - "-c"
-            - >-
-              if [ -n "$(find . -name 'values.yaml' | head -1)" ] &&
-                 [ -n "$(find . -name 'Chart.yaml' | head -1)" ] &&
-                 [ -n "$(find . -name '*.yaml' | xargs -I {} grep '<path\|avp\.kubernetes\.io' {})" ] &&
-                 [ -z "$(find . -name 'kustomization.yaml')" ] &&
-                 [ -z "${ARGOCD_ENV_helm_args}" ]; 
+            - |
+              if [ -n "$(find . -name 'Chart.yaml')" ] &&
+                [ -n "$(find . -name 'values.yaml')" ] &&
+                [ -n "${ARGOCD_ENV_HELM_VALUES}" ];
               then
-                echo "Hit!"
+                echo "ARGOCD_ENV_HELM_VALUES"
               fi
       init:
-        command: [sh, -c, "helm dependency update"]  
+        command: [ sh, -c, "helm dependency update" ]
       generate:
         command:
           - bash
           - "-c"
-          - >-
-            helm template $ARGOCD_APP_NAME -n $ARGOCD_APP_NAMESPACE -f <(echo "$ARGOCD_ENV_HELM_VALUES") . |
+          - |
+            helm template --include-crds $ARGOCD_APP_NAME -n $ARGOCD_APP_NAMESPACE -f <(echo "$ARGOCD_ENV_HELM_VALUES") . |
             argocd-vault-plugin generate - -s $ARGOCD_APP_NAMESPACE:vault-secret
+      lockRepo: false
+  avp-kustomize.yaml: |
+    ---
+    apiVersion: argoproj.io/v1alpha1
+    kind: ConfigManagementPlugin
+    metadata:
+      name: argocd-vault-plugin-kustomize
+    spec:
+      allowConcurrency: true
+      discover:
+        find:
+          command: [ sh, -c, "find . -name kustomization.yaml" ]
+      generate:
+        command: [ sh, -c, "kustomize build . | argocd-vault-plugin generate - -s $ARGOCD_APP_NAMESPACE:vault-secret" ]
       lockRepo: false
   avp.yaml: |
     apiVersion: argoproj.io/v1alpha1
@@ -123,12 +90,11 @@ data:
             - sh
             - "-c"
             - >-
-              if [ -z "$(find . -name 'Chart.yaml')" ] &&
-                 [ -z "$(find . -name 'kustomization.yaml')" ] &&
-                 [ -n "$(find . -name '*.yaml')" ] &&
+              if [ -z "${ARGOCD_ENV_helm_args}" ] &&
+                 [ -z "${ARGOCD_ENV_HELM_VALUES}" ] &&
                  [ -n "$(find . -name '*.yaml' | xargs -I {} grep '<path\|avp\.kubernetes\.io' {})" ];
               then
-                 echo "Hit!"
+                 echo "PLAIN_AVP"
               fi
       generate:
         command:


### PR DESCRIPTION
AVP setup has been refactored to get ENVs in sync again. STABLE Env had a different, simplified AVP setup to support the limitation introduced to the STABLE env.

With this AVP setup the kustomize-helm avp plugin has been removed, as we're not using it anymore (although there seems to be a leftover, see also eclipse-tractusx/sig-infra#322).

This AVP Setup has been tested 2 ways:

### Simple condition checking

The condition checking was done using this simple sh script:

```shell
#!/usr/bin/env sh

cd ../kube-prometheus-stack # here we have kustomization.yaml and values.yaml
pwd

#ARGOCD_ENV_helm_args=" "
#ARGOCD_ENV_HELM_VALUES=" "

if [ -n "$(find . -name 'Chart.yaml')" ] && # if find output is nonzero
   [ -n "$(find . -name 'values.yaml')" ] && # if find output is nonzero
   [ -n "${ARGOCD_ENV_helm_args}" ]; # if var ARGOCD_ENV_helm_args is defined and nonzero
then
  echo "ARGOCD_ENV_helm_args!"
fi

if [ -n "$(find . -name 'Chart.yaml')" ] &&
   [ -n "$(find . -name 'values.yaml')" ] &&
   [ -n "${ARGOCD_ENV_HELM_VALUES}" ];
then
  echo "ARGOCD_ENV_HELM_VALUES"
fi

if [ -n "$(find . -name 'kustomization.yaml')" ] &&
   [ -z "$(find . -name 'Chart.yaml')" ] &&
   [ -z "$(find . -name 'values.yaml')" ];
then
  echo "KUSTOMIZE"
fi

if [ -z "${ARGOCD_ENV_helm_args}" ] &&
   [ -z "${ARGOCD_ENV_HELM_VALUES}" ] &&
   [ -z "$(find . -name 'kustomization.yaml')" ] &&
   [ -n "$(find . -name '*.yaml' -0 | xargs -I {} grep '<path\|avp\.kubernetes\.io' {})" ];
then
  echo "PLAIN_AVP"
fi
```

After successful testing the condition checks have been applied to the ArgoCD Vault Pluging discovery sections.

### Testing on DevSecOps Cluster

This AVP setup has been applied to DevSecOps-Testing cluster manually editing the `cmp-plugin` configMap, and the `argocd-repo-server` deployment.

To test two ArgoCD Applications have been deployed, one using `HELM_VALUES` like it's applied on STABLE env, and one using `helm_args` as the teams are used to it on DEV/INT environment.

For `HELM_VALUES` testing the Portal ArgoCD App was used with ingress set to `false` and changed URLs to avoid side effects to existing deployments.

For `helm_args` testing one of my AVP demo charts was used.

Both ArgoCD apps deployed as expected and gathered the secrets from Vault.