### PR TITLE
chore: fix api resource version

### DIFF
--- a/apps/kyverno/values.yaml
+++ b/apps/kyverno/values.yaml
@@ -1,4 +1,6 @@
 kyverno:
+  apiVersionOverride:
+    podDisruptionBudget: policy/v1
   config:
     webhookAnnotations:
       "admissions.enforcer/disabled": true


### PR DESCRIPTION
For whatever reason the automatic determination of api-resource version for podDisruptionBudget fails. The Helm Chart provides a way to set apiVersion for that.

ArgoCD error was:

```
The Kubernetes API could not find version "v1beta1" of policy/PodDisruptionBudget for
requested resource kyverno/kyverno-background-controller. 
Version "v1" of policy/PodDisruptionBudget is installed on the destination cluster.
```