### PR TITLE
chore: deploy kyverno dashboard to monitoring ns

### DIFF
--- a/apps/kyverno/values.yaml
+++ b/apps/kyverno/values.yaml
@@ -12,3 +12,7 @@ kyverno:
     replicas: 2
   reportsController:
     replicas: 2
+  grafana:
+    enabled: true
+    namespace: monitoring
+    configMapName: kyverno-dashboards


### PR DESCRIPTION
deploy the kyverno dashboard(s) to the kube-prometheus-stack namespace. In a second step the kube-prometheus-stack setup needs adjustments to implement this dashboard into grafana.