### PR TITLE
feat: make kyverno a multi-source AppSet

### DIFF
--- a/environments/core/applicationsets/kyverno-applicationset.yaml
+++ b/environments/core/applicationsets/kyverno-applicationset.yaml
@@ -6,9 +6,9 @@ spec:
   generators:
     - list:
         elements:
-          - cluster: devsecops-testing
-            cluster-name: devsecops-testing
-            targetRevision: feat/kyverno-monitoring
+#          - cluster: devsecops-testing
+#            cluster-name: devsecops-testing
+#            targetRevision: feat/kyverno-monitoring
           - cluster: dev
             cluster-name: dev
             targetRevision: HEAD

--- a/environments/core/applicationsets/kyverno-multisource-applicationset.yaml
+++ b/environments/core/applicationsets/kyverno-multisource-applicationset.yaml
@@ -47,7 +47,7 @@ spec:
               - $values/apps/{{appName}}/values-{{cluster-name}}.yaml
         - repoURL: 'https://github.com/catenax-ng/k8s-cluster-stack'
           targetRevision: HEAD
-          ref: value
+          ref: values
       destination:
         name: '{{cluster-name}}'
         namespace: '{{appName}}'

--- a/environments/core/applicationsets/kyverno-multisource-applicationset.yaml
+++ b/environments/core/applicationsets/kyverno-multisource-applicationset.yaml
@@ -1,0 +1,60 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: kyverno-multisource-applicationset
+spec:
+  generators:
+    - list:
+        elements:
+          - cluster: devsecops-testing
+            cluster-name: devsecops-testing
+            targetRevision: feat/kyverno-monitoring
+            appName: 'kyverno'
+#          - cluster: dev
+#            cluster-name: dev
+#            targetRevision: HEAD
+#            appName: 'kyverno'
+#          - cluster: hotel-budapest
+#            cluster-name: hotel-budapest
+#            targetRevision: HEAD
+#            appName: 'kyverno'
+#          - cluster: pre-prod
+#            cluster-name: pre-prod
+#            targetRevision: HEAD
+#            appName: 'kyverno'
+#          - cluster: beta
+#            cluster-name: beta
+#            targetRevision: HEAD
+#            appName: 'kyverno'
+#          - cluster: stable
+#            cluster-name: stable
+#            targetRevision: HEAD
+#            appName: 'kyverno'
+  template:
+    metadata:
+      name: '{{cluster}}-kyverno'
+      labels:
+        app: '{{appName}}'
+    spec:
+      project: default
+      sources:
+        - repoURL: https://kyverno.github.io/kyverno
+          chart: '{{appName}}'
+          targetRevision: 3.0.6
+          helm:
+            valueFiles:
+              - $values/apps/kyverno/values.yaml
+              - $values/apps/{{appName}}/values-{{cluster-name}}.yaml
+        - repoURL: 'https://github.com/catenax-ng/k8s-cluster-stack'
+          targetRevision: HEAD
+          ref: value
+      destination:
+        name: '{{cluster-name}}'
+        namespace: '{{appName}}'
+        server: ''
+
+      # Sync policy
+      syncPolicy:
+        syncOptions:
+          - ServerSideApply=true # https://kyverno.io/docs/installation/#notes-for-argocd-users
+          - CreateNamespace=true


### PR DESCRIPTION
To manage different pitfalls of kyverno deployment in our (ArgoCD) setup, refactor AppSet to use multi-source.

Reasons:
- As ApplicationSets support multi-source there is no need for creating an umbrella Helm Chart to deploy Kyverno. Refer to https://github.com/argoproj/argo-cd/blob/release-2.7/docs/user-guide/helm.md#values-files
- `apps/kyverno/` will only contain global values (`values.yaml`) and env specific values (`values-envName.yaml`).
- For `serviceMonitor` configuration, environment specific values are required.

For testing purpose, the multi-source AppSet is only applied to devsecops-testing cluster. In former Kyverno AppSet this cluster has been removed/commented.