### PR TITLE
chore: bump kyverno to 1.10.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 .vscode
+**/.DS_Store
 apps/**/charts/
 apps/**/Chart.lock
 

--- a/environments/core/applicationsets/kyverno-multisource-applicationset.yaml
+++ b/environments/core/applicationsets/kyverno-multisource-applicationset.yaml
@@ -36,7 +36,7 @@ spec:
       sources:
         - repoURL: 'https://kyverno.github.io/kyverno'
           chart: kyverno
-          targetRevision: 3.0.6
+          targetRevision: 3.0.7
           helm:
             valueFiles:
               - $values/{{path}}/kyverno/values.yaml


### PR DESCRIPTION
New Helm Chart Version: 3.0.7
New Kyverno Version: 1.10.5

```shell
helm search repo kyverno/kyverno --versions | head -n4
NAME                            CHART VERSION   APP VERSION     DESCRIPTION
kyverno/kyverno                 3.1.0           v1.11.0         Kubernetes Native Policy Management
kyverno/kyverno                 3.0.7           v1.10.5         Kubernetes Native Policy Management
kyverno/kyverno                 3.0.6           v1.10.4         Kubernetes Native Policy Management
```

Kyverno 1.11.0 is available, but there is no release note available, omitting bumping to 1.11.0.

Add `DS_Store` to `.gitignore`