### PR TITLE
chore: ingress-nginx as multi-source appset (step 1)

### DIFF
--- a/environments/core/applicationsets/ingress-applicationset.yaml
+++ b/environments/core/applicationsets/ingress-applicationset.yaml
@@ -18,9 +18,9 @@ spec:
       - cluster: vault
         cluster-name: vault-cluster
         targetRevision: HEAD
-      - cluster: devsecops-testing
-        cluster-name: devsecops-testing
-        targetRevision: HEAD
+#      - cluster: devsecops-testing
+#        cluster-name: devsecops-testing
+#        targetRevision: HEAD
       - cluster: stable
         cluster-name: stable
         targetRevision: HEAD

--- a/environments/core/applicationsets/ingress-multisource-applicationset.yaml
+++ b/environments/core/applicationsets/ingress-multisource-applicationset.yaml
@@ -1,0 +1,57 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: ingress-multisource-applicationset
+spec:
+  generators:
+    - list:
+        elements:
+#          - cluster: core
+#            cluster-name: in-cluster
+#            targetRevision: HEAD
+#            path: 'apps/ingress-nginx'
+#          - cluster: dev
+#            cluster-name: dev
+#            targetRevision: HEAD
+#            path: 'apps/ingress-nginx'
+          - cluster: devsecops-testing
+            cluster-name: devsecops-testing
+            targetRevision: chore/ingress-as-multi-source-app
+            path: 'apps/ingress-nginx'
+#          - cluster: hotel-budapest
+#            cluster-name: hotel-budapest
+#            targetRevision: HEAD
+#            path: 'apps/ingress-nginx'
+#          - cluster: stable
+#            cluster-name: stable
+#            targetRevision: HEAD
+#            path: 'apps/ingress-nginx'
+  template:
+    metadata:
+      name: '{{cluster}}-ingress-nginx'
+      labels:
+        app: 'ingress-nginx'
+    spec:
+      project: default
+      sources:
+        - repoURL: 'https://kubernetes.github.io/ingress-nginx'
+          chart: ingress-nginx
+          targetRevision: 4.7.1
+          helm:
+            valueFiles:
+              - $values/{{path}}/values.yaml
+              - $values/{{path}}/values-{{cluster-name}}.yaml
+        - repoURL: 'https://github.com/catenax-ng/k8s-cluster-stack'
+          targetRevision: '{{targetRevision}}'
+          ref: values
+      destination:
+        name: '{{cluster-name}}'
+        namespace: 'default'
+        server: ''
+
+      # Sync policy
+      syncPolicy:
+#        automated: {}
+        syncOptions:
+          - ServerSideApply=true # https://ingress.io/docs/installation/#notes-for-argocd-users
+          - CreateNamespace=true


### PR DESCRIPTION
Provide `ingress-nginx` as mult-source applicationset and enable it for devsecops-testing cluster for testing purpose. Branch `chore/ingress-as-multi-source-app` not yet pushed to repo.

eclipse-tractusx/sig-infra#350