### PR TITLE
chore: add ignoreDifferences for aks managed by

### DIFF
--- a/environments/core/applicationsets/certmanager-applicationset.yaml
+++ b/environments/core/applicationsets/certmanager-applicationset.yaml
@@ -61,9 +61,12 @@ spec:
             factor: 2 # a factor to multiply the base duration after each failed retry
             maxDuration: 3m # the maximum amount of time allowed for the backoff strategy
 
-      ignoreDifferences: # https://github.com/argoproj/argo-cd/issues/4276#issuecomment-908455476
+      ignoreDifferences:
         - group: admissionregistration.k8s.io
           kind: ValidatingWebhookConfiguration
           name: '{{ cluster }}-certmanager-webhook'
-          jsonPointers:
-            - /webhooks/0/namespaceSelector/matchExpressions/2
+#          jsonPointers:
+#            - /webhooks/0/namespaceSelector/matchExpressions/2
+          jqPathExpressions:
+            - .webhooks[].namespaceSelector.matchExpressions[] | select(.key == "control-plane") # https://github.com/argoproj/argo-cd/issues/4276#issuecomment-907797060
+            - .webhooks[].namespaceSelector.matchExpressions[] | select(.key == "kubernetes.azure.com/managedby") # https://github.com/cert-manager/cert-manager/issues/4114#issuecomment-1008162907


### PR DESCRIPTION
Adjust `ignoreDifferences` to fix OutOfSync status of resource `validatingwebhookconfiguration`:

![grafik](https://github.com/catenax-ng/k8s-cluster-stack/assets/28647218/70218cc2-8a32-4c5f-8caa-676d4f7911ed)

eclipse-tractusx/sig-infra#366