### PR TITLE
fix: increase mem limit for kyverno-reports-controller

### DIFF
--- a/apps/kyverno/kyverno/values.yaml
+++ b/apps/kyverno/kyverno/values.yaml
@@ -11,5 +11,8 @@ cleanupController:
   replicas: 2
 reportsController:
   replicas: 2
+  resources:
+    limits:
+      memory: 128Mi
 grafana:
   enabled: true

--- a/apps/kyverno/kyverno/values.yaml
+++ b/apps/kyverno/kyverno/values.yaml
@@ -13,6 +13,6 @@ reportsController:
   replicas: 2
   resources:
     limits:
-      memory: 128Mi
+      memory: 256Mi
 grafana:
   enabled: true


### PR DESCRIPTION
PR to increase mem limits for kyverno-reports-controller due to crashing pods because of OOM issue.