### PR TITLE
fix: increase mem limit of kyverno reports controller

### DIFF
--- a/apps/kyverno/kyverno/values.yaml
+++ b/apps/kyverno/kyverno/values.yaml
@@ -13,6 +13,6 @@ reportsController:
   replicas: 2
   resources:
     limits:
-      memory: 256Mi
+      memory: 512Mi
 grafana:
   enabled: true


### PR DESCRIPTION
PR to increase memory limit to 512Mi for  kyverno reports controller which is failing due to OOM at dev cluster.