### PR TITLE
chore(deps): bump Argo CD to 2.7.16

### DIFF
--- a/apps/argocd/base/kustomization.yaml
+++ b/apps/argocd/base/kustomization.yaml
@@ -7,11 +7,11 @@ namespace: argocd
 # https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/images/
 images:
   - name: quay.io/argoproj/argocd
-    newTag: v2.7.14
+    newTag: v2.7.16
 
 resources:
   - namespace.yaml
-  - https://raw.githubusercontent.com/argoproj/argo-cd/v2.7.14/manifests/ha/install.yaml # ensure to keep images.newTag in sync
+  - https://raw.githubusercontent.com/argoproj/argo-cd/v2.7.16/manifests/ha/install.yaml # ensure to keep images.newTag in sync
   - vault-plugin/vault-plugin-cm.yaml # AVP sidecar configuration
   - avp-rbac-secret-access.yaml # grant avp access to secret with AVP configuration
 

--- a/environments/core/applicationsets/argo-applicationset.yaml
+++ b/environments/core/applicationsets/argo-applicationset.yaml
@@ -9,15 +9,15 @@ spec:
       - cluster: core
         cluster-name: in-cluster
         overlay: overlays/core
-        targetRevision: ArgoCD-v2.7.14-c4_AVP-v1.16.1
+        targetRevision: ArgoCD-v2.7.16-c0_AVP-v1.16.1
       - cluster: hotel-budapest
         cluster-name: hotel-budapest
         overlay: overlays/hotel-budapest
-        targetRevision: ArgoCD-v2.7.14-c3_AVP-v1.16.1
+        targetRevision: ArgoCD-v2.7.16-c0_AVP-v1.16.1
       - cluster: dev
         cluster-name: dev
         overlay: overlays/dev
-        targetRevision: ArgoCD-v2.7.14-c3_AVP-v1.16.1
+        targetRevision: ArgoCD-v2.7.16-c0_AVP-v1.16.1
       - cluster: devsecops-testing
         cluster-name: devsecops-testing
         overlay: overlays/devsecops-testing
@@ -25,7 +25,7 @@ spec:
       - cluster: stable
         cluster-name: stable
         overlay: overlays/stable
-        targetRevision: ArgoCD-v2.7.14-c3_AVP-v1.16.1
+        targetRevision: ArgoCD-v2.7.16-c0_AVP-v1.16.1
 
   template:
     metadata:


### PR DESCRIPTION
Update our Argo CD instances to latest patch version of 2.7. The Argo CD instances will be updated after DEVSECOPS-TESTING cluster has been updated and tested successfully by pushing the new GH Tag `ArgoCD-v2.7.16-c0_AVP-v1.16.1` to the repository.

Argo CD Release Notes:
- https://github.com/argoproj/argo-cd/releases/tag/v2.7.15
- https://github.com/argoproj/argo-cd/releases/tag/v2.7.16