### PR TITLE
Upgrade certmanager 1.14.4

### DIFF
--- a/apps/certmanager/Chart.yaml
+++ b/apps/certmanager/Chart.yaml
@@ -26,5 +26,5 @@ appVersion: "1.16.0"
 dependencies:
 - name: cert-manager
   alias: certmanager
-  version: 1.12.2
+  version: 1.14.4
   repository: https://charts.jetstack.io

--- a/environments/core/applicationsets/certmanager-applicationset.yaml
+++ b/environments/core/applicationsets/certmanager-applicationset.yaml
@@ -20,7 +20,7 @@ spec:
         targetRevision: HEAD
       - cluster: devsecops-testing
         cluster-name: devsecops-testing
-        targetRevision: upgrade_certmanager_1.14.4
+        targetRevision: HEAD
       - cluster: stable
         cluster-name: stable
         targetRevision: HEAD


### PR DESCRIPTION
Upgrade cert-manager to 1.14.4 on all clusters.

Updates https://github.com/eclipse-tractusx/sig-infra/issues/454